### PR TITLE
GH-37,38,64: [RTI][TOOL][BACKEND] RTI Template Update, Deletion and Read by ID APIs

### DIFF
--- a/tool/backend/src/models/request_models/__init__.py
+++ b/tool/backend/src/models/request_models/__init__.py
@@ -1,5 +1,8 @@
 from .senders import SenderRequest
+from .rti_templates import RTITemplateRequest
 
 __all__ = [
-    "SenderRequest"
+    "SenderRequest",
+    "RTITemplateRequest"
 ]
+

--- a/tool/backend/src/models/request_models/rti_templates.py
+++ b/tool/backend/src/models/request_models/rti_templates.py
@@ -1,1 +1,11 @@
-# add request models in this file
+from fastapi import UploadFile
+from typing import Optional
+from pydantic import BaseModel, ConfigDict, Field
+
+class RTITemplateRequest(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    # attributes
+    id: Optional[str] = Field(None, description="ID of the RTI Template")
+    title: Optional[str] = Field(None, description="Title of the RTI Template")
+    description: Optional[str] = Field(None, description="Detailed description of the RTI Template")
+    file: Optional[UploadFile] = Field(None, description="RTI Template markdown file")

--- a/tool/backend/src/models/response_models/__init__.py
+++ b/tool/backend/src/models/response_models/__init__.py
@@ -1,4 +1,4 @@
-from .rti_templates import RTITemplateResponse, RTITemplateListResponse, RTITemplateRequest
+from .rti_templates import RTITemplateResponse, RTITemplateListResponse
 from .institutions import InstitutionListResponse, InstitutionResponse
 from .positions import PositionListResponse, PositionResponse
 from .senders import SenderResponse, SenderListResponse
@@ -6,7 +6,6 @@ from .senders import SenderResponse, SenderListResponse
 __all__ = [
     "RTITemplateResponse",
     "RTITemplateListResponse",
-    "RTITemplateRequest",
     "SenderResponse",
     "SenderListResponse",
     "InstitutionListResponse",

--- a/tool/backend/src/models/response_models/__init__.py
+++ b/tool/backend/src/models/response_models/__init__.py
@@ -9,7 +9,7 @@ __all__ = [
     "SenderResponse",
     "SenderListResponse",
     "InstitutionListResponse",
-    "InstitutionResponse"
+    "InstitutionResponse",
     "PositionListResponse",
     "PositionResponse"
 ]

--- a/tool/backend/src/models/response_models/rti_templates.py
+++ b/tool/backend/src/models/response_models/rti_templates.py
@@ -13,7 +13,7 @@ class RTITemplateResponse(BaseModel):
     id: UUID = Field(..., description="Unique identifier for the RTI template")
     title: str = Field(..., description="Title of the RTI template")
     description: Optional[str] = Field(None, description="Detailed description of the RTI template")
-    file: str = Field(..., description="Content of the RTI template in Markdown format")
+    file: str = Field(..., description="Relative path of the markdown file")
     created_at: datetime = Field(..., description="ISO 8601 timestamp of when the template was created")
     updated_at: datetime = Field(..., description="ISO 8601 timestamp of when the template was last updated")
 

--- a/tool/backend/src/models/response_models/rti_templates.py
+++ b/tool/backend/src/models/response_models/rti_templates.py
@@ -6,12 +6,6 @@ from src.models import PaginationModel
 from typing import Sequence, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
-class RTITemplateRequest(BaseModel):
-    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
-    # attributes
-    title: str = Field(..., description="Title of the RTI Template")
-    description: Optional[str] = Field(None, description="Detailed description of the RTI Template")
-    file: UploadFile = Field(..., description="RTI Template markdown file")
     
 class RTITemplateResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)

--- a/tool/backend/src/models/table_schemas/table_schemas.py
+++ b/tool/backend/src/models/table_schemas/table_schemas.py
@@ -16,15 +16,12 @@ class RTITemplate(SQLModel, table=True):
         None, description="Detailed description of the RTI template"
     )
     file: str = Field(..., description="URL of the RTI template markdown file")
-    created_at: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc),
-        description="ISO 8601 timestamp of when the template was created",
-    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the template was created")
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
-        description="ISO 8601 timestamp of when the template was last updated",
+        sa_column_kwargs={"onupdate": func.now()},
+        description="ISO 8601 timestamp of when the template was last updated"
     )
-
 
 class Institution(SQLModel, table=True):
     __tablename__ = "institutions"

--- a/tool/backend/src/routers/rti_template_router.py
+++ b/tool/backend/src/routers/rti_template_router.py
@@ -37,6 +37,14 @@ async def create_rti_templates_endpoint(
     response = await service.create_rti_template(template_request=template_request)
     return response
 
+@router.get("/rti_templates/{id}", response_model=RTITemplateResponse)
+def get_rti_template_by_id_endpoint(
+    id: Annotated[str, Path(title="ID of the RTI Template")],
+    service: RTITemplateService = Depends(get_rti_template_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+):
+    return service.get_rti_template_by_id(template_id=id)
+
 @router.put("/rti_templates/{id}")
 async def update_rti_template_endpoint(
     id: Annotated[str, Path(title="ID of the RTI Template")],

--- a/tool/backend/src/routers/rti_template_router.py
+++ b/tool/backend/src/routers/rti_template_router.py
@@ -1,8 +1,10 @@
+from fastapi import Path
 from fastapi import APIRouter, Depends, Query, Form, UploadFile, File
 from typing import Annotated, Optional
 from src.services import RTITemplateService, GithubFileService
 from src.repositories.db import SessionDep
-from src.models.response_models import RTITemplateListResponse, RTITemplateResponse, RTITemplateRequest
+from src.models.response_models import RTITemplateListResponse, RTITemplateResponse
+from src.models.request_models import RTITemplateRequest
 from src.models import User, UserRole
 from src.dependencies import RoleChecker
 
@@ -30,10 +32,23 @@ async def create_rti_templates_endpoint(
     file: Annotated[UploadFile, File(description="RTI Template markdown file")],
     description: Annotated[Optional[str], Form(description="Detailed description of the RTI Template")] = None,
     service: RTITemplateService = Depends(get_rti_template_service),
-    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     template_request = RTITemplateRequest(title=title, description=description, file=file)
     response = await service.create_rti_template(template_request=template_request)
+    return response
+
+@router.put("/rti_template/{id}")
+async def update_rti_template_endpoint(
+    id: Annotated[str, Path(title="ID of the RTI Template")],
+    title: Annotated[Optional[str], Form(description="Title of the RTI Template")] = None,
+    file: Annotated[Optional[UploadFile], File(description="RTI Template markdown file")] = None,
+    description: Annotated[Optional[str], Form(description="Detailed description of the RTI Template")] = None,
+    service: RTITemplateService = Depends(get_rti_template_service),
+    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+):
+    template_request = RTITemplateRequest(id=id, title=title, description=description, file=file)
+    response = await service.update_rti_template(template_request=template_request)
     return response
 
 

--- a/tool/backend/src/routers/rti_template_router.py
+++ b/tool/backend/src/routers/rti_template_router.py
@@ -32,20 +32,20 @@ async def create_rti_templates_endpoint(
     file: Annotated[UploadFile, File(description="RTI Template markdown file")],
     description: Annotated[Optional[str], Form(description="Detailed description of the RTI Template")] = None,
     service: RTITemplateService = Depends(get_rti_template_service),
-    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     template_request = RTITemplateRequest(title=title, description=description, file=file)
     response = await service.create_rti_template(template_request=template_request)
     return response
 
-@router.put("/rti_template/{id}")
+@router.put("/rti_templates/{id}")
 async def update_rti_template_endpoint(
     id: Annotated[str, Path(title="ID of the RTI Template")],
     title: Annotated[Optional[str], Form(description="Title of the RTI Template")] = None,
     file: Annotated[Optional[UploadFile], File(description="RTI Template markdown file")] = None,
     description: Annotated[Optional[str], Form(description="Detailed description of the RTI Template")] = None,
     service: RTITemplateService = Depends(get_rti_template_service),
-    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     template_request = RTITemplateRequest(id=id, title=title, description=description, file=file)
     response = await service.update_rti_template(template_request=template_request)

--- a/tool/backend/src/routers/rti_template_router.py
+++ b/tool/backend/src/routers/rti_template_router.py
@@ -32,7 +32,7 @@ async def create_rti_templates_endpoint(
     file: Annotated[UploadFile, File(description="RTI Template markdown file")],
     description: Annotated[Optional[str], Form(description="Detailed description of the RTI Template")] = None,
     service: RTITemplateService = Depends(get_rti_template_service),
-    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     template_request = RTITemplateRequest(title=title, description=description, file=file)
     response = await service.create_rti_template(template_request=template_request)
@@ -45,11 +45,21 @@ async def update_rti_template_endpoint(
     file: Annotated[Optional[UploadFile], File(description="RTI Template markdown file")] = None,
     description: Annotated[Optional[str], Form(description="Detailed description of the RTI Template")] = None,
     service: RTITemplateService = Depends(get_rti_template_service),
-    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     template_request = RTITemplateRequest(id=id, title=title, description=description, file=file)
     response = await service.update_rti_template(template_request=template_request)
     return response
+
+@router.delete("/rti_templates/{id}")
+async def delete_rti_template_endpoint(
+    id: Annotated[str, Path(title="ID of the RTI Template")],
+    service: RTITemplateService = Depends(get_rti_template_service),
+    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+):
+    response = await service.delete_rti_template(template_id=id)
+    return response
+
 
 
 

--- a/tool/backend/src/routers/rti_template_router.py
+++ b/tool/backend/src/routers/rti_template_router.py
@@ -1,5 +1,4 @@
-from fastapi import Path
-from fastapi import APIRouter, Depends, Query, Form, UploadFile, File
+from fastapi import APIRouter, Depends, Query, Form, UploadFile, File, Path, status
 from typing import Annotated, Optional
 from src.services import RTITemplateService, GithubFileService
 from src.repositories.db import SessionDep
@@ -32,7 +31,7 @@ async def create_rti_templates_endpoint(
     file: Annotated[UploadFile, File(description="RTI Template markdown file")],
     description: Annotated[Optional[str], Form(description="Detailed description of the RTI Template")] = None,
     service: RTITemplateService = Depends(get_rti_template_service),
-    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     template_request = RTITemplateRequest(title=title, description=description, file=file)
     response = await service.create_rti_template(template_request=template_request)
@@ -45,20 +44,20 @@ async def update_rti_template_endpoint(
     file: Annotated[Optional[UploadFile], File(description="RTI Template markdown file")] = None,
     description: Annotated[Optional[str], Form(description="Detailed description of the RTI Template")] = None,
     service: RTITemplateService = Depends(get_rti_template_service),
-    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     template_request = RTITemplateRequest(id=id, title=title, description=description, file=file)
     response = await service.update_rti_template(template_request=template_request)
     return response
 
-@router.delete("/rti_templates/{id}")
+@router.delete("/rti_templates/{id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_rti_template_endpoint(
     id: Annotated[str, Path(title="ID of the RTI Template")],
     service: RTITemplateService = Depends(get_rti_template_service),
-    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
-    response = await service.delete_rti_template(template_id=id)
-    return response
+    await service.delete_rti_template(template_id=id)
+    return None
 
 
 

--- a/tool/backend/src/services/github_file_service.py
+++ b/tool/backend/src/services/github_file_service.py
@@ -117,7 +117,7 @@ class GithubFileService:
             return False
 
     # get file
-    async def get_file(self, file_path: str) -> Dict:
+    async def read_file(self, file_path: str) -> Dict:
         """Fetches the content and SHA of a file from GitHub."""
         try:
             contents = self.repository.get_contents(file_path, ref=self.branch)
@@ -130,6 +130,4 @@ class GithubFileService:
         except GithubException as e:
             logger.error(f"[FILE SERVICE] Error fetching file from github: {e}")
             raise InternalServerException("[FILE SERVICE] Failed to fetch file from github") from e
-
-
 

--- a/tool/backend/src/services/github_file_service.py
+++ b/tool/backend/src/services/github_file_service.py
@@ -78,6 +78,55 @@ class GithubFileService:
             logger.error(f"[FILE SERVICE] Error uploading file to github: {e}")
             raise InternalServerException("[FILE SERVICE] Failed to upload file to github") from e
     
+    # update file
+    async def update_file(self, template_id, file: UploadFile) -> Dict:
+        """Updates a Markdown file in the GitHub repository under rti-templates directory and returns its relative and absolute paths."""
+
+        # validate the file type
+        if file.content_type not in self.ALLOWED_FILE_TYPES:
+            raise BadRequestException(f'{file.content_type} is not allowed')
+
+        try:
+            # define the file path
+            content = await file.read()
+            file_path = f"rti-templates/{template_id}.md"
+
+            existing_file = self.repository.get_contents(file_path, ref=self.branch)
+
+            # update the existing file
+            response = self.repository.update_file(
+                path=file_path,
+                message=f"Update content of {file.filename}",
+                content=content,
+                sha=existing_file.sha,
+                branch=self.branch
+            )
+            
+            content_file = response.get("content", None)
+            relative_path = content_file.path if content_file is not None else None
+
+            if relative_path is not None:
+                absolute_path = self.get_github_file_path(
+                    repo_name=self.github_repository_name,
+                    branch=self.branch,
+                    file_path=relative_path
+                    )
+
+                final_response = {
+                    "relative_path": relative_path,
+                    "absolute_path": absolute_path
+                }
+
+                return final_response
+            else:
+                return {
+                    "relative_path": "",
+                    "absolute_path": ""
+                }
+
+        except GithubException as e:
+            logger.error(f"[FILE SERVICE] Error updating file to github: {e}")
+    
     # delete file
     async def delete_file(self, file_path: str) -> bool:
         """Deletes a file from the GitHub repository. Used as a compensating transaction on downstream failure. Returns False instead of raising if the cleanup itself fails."""

--- a/tool/backend/src/services/github_file_service.py
+++ b/tool/backend/src/services/github_file_service.py
@@ -1,10 +1,9 @@
 from typing import Dict
-import uuid
 from src.core import settings
 from src.core.exceptions import BadRequestException, InternalServerException
-from fastapi import UploadFile
 from github import Github, GithubException
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -22,32 +21,19 @@ class GithubFileService:
         self.github = Github(self.github_token)
         self.repository = self.github.get_repo(self.github_repository_name)
 
-    ALLOWED_FILE_TYPES = ["text/markdown"]
-
     # helper
     @staticmethod
     def get_github_file_path(repo_name: str, branch: str, file_path: str) -> str:
         return f"https://github.com/{repo_name}/blob/{branch}/{file_path}"
 
-    # upload file
-    async def upload_file(self, template_id: uuid, file: UploadFile) -> Dict:
-        """Uploads a Markdown file to the GitHub repository under rti-templates/<uuid>.md and returns its relative and absolute paths."""
-
-        # validate the file type
-        if file.content_type not in self.ALLOWED_FILE_TYPES:
-            raise BadRequestException(f'{file.content_type} is not allowed')
-        
+    # create file
+    async def create_file(self, file_path: str, content: bytes, message: str = "Upload file") -> Dict:
+        """Uploads a file to the GitHub repository and returns its relative and absolute paths."""
         try:
-            # read the file content
-            content = await file.read()
-
-            # define the file path
-            file_path = f"rti-templates/{template_id}.md"
-
             # upload to github
             response = self.repository.create_file(
                 path=file_path,
-                message=f"Upload file {file.filename}",
+                message=message,
                 content=content,
                 branch=self.branch
             )
@@ -56,18 +42,16 @@ class GithubFileService:
             relative_path = content_file.path if content_file is not None else None
 
             if relative_path is not None:
-                absolute_path = GithubFileService.get_github_file_path(
+                absolute_path = self.get_github_file_path(
                     repo_name=self.github_repository_name,
                     branch=self.branch,
                     file_path=relative_path
                     )
 
-                final_response = {
+                return {
                     "relative_path": relative_path,
                     "absolute_path": absolute_path
                 }
-
-                return final_response
             else:
                 return {
                     "relative_path": "",
@@ -75,30 +59,19 @@ class GithubFileService:
                 }
 
         except GithubException as e:
-            logger.error(f"[FILE SERVICE] Error uploading file to github: {e}")
-            raise InternalServerException("[FILE SERVICE] Failed to upload file to github") from e
+            logger.error(f"[FILE SERVICE] Error creating file on github: {e}")
+            raise InternalServerException("[FILE SERVICE] Failed to create file on github") from e
     
     # update file
-    async def update_file(self, template_id, file: UploadFile) -> Dict:
-        """Updates a Markdown file in the GitHub repository under rti-templates directory and returns its relative and absolute paths."""
-
-        # validate the file type
-        if file.content_type not in self.ALLOWED_FILE_TYPES:
-            raise BadRequestException(f'{file.content_type} is not allowed')
-
+    async def update_file(self, file_path: str, content: bytes, sha: str, message: str = "Update content") -> Dict:
+        """Updates a file in the GitHub repository and returns its relative and absolute paths."""
         try:
-            # define the file path
-            content = await file.read()
-            file_path = f"rti-templates/{template_id}.md"
-
-            existing_file = await self.get_file(template_id)
-
             # update the existing file
             response = self.repository.update_file(
                 path=file_path,
-                message=f"Update content of {file.filename}",
+                message=message,
                 content=content,
-                sha=existing_file["sha"],
+                sha=sha,
                 branch=self.branch
             )
             
@@ -112,12 +85,10 @@ class GithubFileService:
                     file_path=relative_path
                     )
 
-                final_response = {
+                return {
                     "relative_path": relative_path,
                     "absolute_path": absolute_path
                 }
-
-                return final_response
             else:
                 return {
                     "relative_path": "",
@@ -125,8 +96,8 @@ class GithubFileService:
                 }
 
         except GithubException as e:
-            logger.error(f"[FILE SERVICE] Error updating file to github: {e}")
-            raise InternalServerException("[FILE SERVICE] Failed to update file to github") from e
+            logger.error(f"[FILE SERVICE] Error updating file on github: {e}")
+            raise InternalServerException("[FILE SERVICE] Failed to update file on github") from e
     
     # delete file
     async def delete_file(self, file_path: str) -> bool:
@@ -146,51 +117,19 @@ class GithubFileService:
             return False
 
     # get file
-    async def get_file(self, template_id: uuid.UUID) -> Dict:
+    async def get_file(self, file_path: str) -> Dict:
         """Fetches the content and SHA of a file from GitHub."""
         try:
-            file_path = f"rti-templates/{template_id}.md"
             contents = self.repository.get_contents(file_path, ref=self.branch)
+            _, ext = os.path.splitext(file_path)
             return {
                 "content": contents.decoded_content,
-                "sha": contents.sha
+                "sha": contents.sha,
+                "extension": ext
             }
         except GithubException as e:
             logger.error(f"[FILE SERVICE] Error fetching file from github: {e}")
             raise InternalServerException("[FILE SERVICE] Failed to fetch file from github") from e
 
-    # restore file
-    async def restore_file(self, template_id: uuid.UUID, content: bytes, sha: str) -> bool:
-        """Restores a file to a previous state. Used as a compensating transaction."""
-        try:
-            file_path = f"rti-templates/{template_id}.md"
-            self.repository.update_file(
-                path=file_path,
-                message=f"Rollback: restore previous version of {template_id}.md",
-                content=content,
-                sha=sha,
-                branch=self.branch
-            )
-            logger.info(f"[FILE SERVICE] Compensating transaction: restored {file_path} on github")
-            return True
-        except GithubException as e:
-            logger.error(f"[FILE SERVICE] Compensating transaction failed — could not restore {template_id}.md: {e}")
-            return False
 
-    # recreate file
-    async def recreate_file(self, template_id: uuid.UUID, content: bytes) -> bool:
-        """Recreates a file that was previously deleted. Used as a compensating transaction."""
-        try:
-            file_path = f"rti-templates/{template_id}.md"
-            self.repository.create_file(
-                path=file_path,
-                message=f"Recreate file {template_id}.md",
-                content=content,
-                branch=self.branch
-            )
-            logger.info(f"[FILE SERVICE] Compensating transaction: recreated {file_path} on github")
-            return True
-        except GithubException as e:
-            logger.error(f"[FILE SERVICE] Compensating transaction failed — could not recreate {template_id}.md: {e}")
-            return False
 

--- a/tool/backend/src/services/github_file_service.py
+++ b/tool/backend/src/services/github_file_service.py
@@ -91,14 +91,14 @@ class GithubFileService:
             content = await file.read()
             file_path = f"rti-templates/{template_id}.md"
 
-            existing_file = self.repository.get_contents(file_path, ref=self.branch)
+            existing_file = await self.get_file(template_id)
 
             # update the existing file
             response = self.repository.update_file(
                 path=file_path,
                 message=f"Update content of {file.filename}",
                 content=content,
-                sha=existing_file.sha,
+                sha=existing_file["sha"],
                 branch=self.branch
             )
             
@@ -143,5 +143,37 @@ class GithubFileService:
             return True
         except GithubException as e:
             logger.error(f"[FILE SERVICE] Compensating transaction failed — could not delete {file_path}: {e}")
+            return False
+
+    # get file
+    async def get_file(self, template_id: uuid.UUID) -> Dict:
+        """Fetches the content and SHA of a file from GitHub."""
+        try:
+            file_path = f"rti-templates/{template_id}.md"
+            contents = self.repository.get_contents(file_path, ref=self.branch)
+            return {
+                "content": contents.decoded_content,
+                "sha": contents.sha
+            }
+        except GithubException as e:
+            logger.error(f"[FILE SERVICE] Error fetching file from github: {e}")
+            raise InternalServerException("[FILE SERVICE] Failed to fetch file from github") from e
+
+    # restore file
+    async def restore_file(self, template_id: uuid.UUID, content: bytes, sha: str) -> bool:
+        """Restores a file to a previous state. Used as a compensating transaction."""
+        try:
+            file_path = f"rti-templates/{template_id}.md"
+            self.repository.update_file(
+                path=file_path,
+                message=f"Rollback: restore previous version of {template_id}.md",
+                content=content,
+                sha=sha,
+                branch=self.branch
+            )
+            logger.info(f"[FILE SERVICE] Compensating transaction: restored {file_path} on github")
+            return True
+        except GithubException as e:
+            logger.error(f"[FILE SERVICE] Compensating transaction failed — could not restore {template_id}.md: {e}")
             return False
 

--- a/tool/backend/src/services/github_file_service.py
+++ b/tool/backend/src/services/github_file_service.py
@@ -126,6 +126,7 @@ class GithubFileService:
 
         except GithubException as e:
             logger.error(f"[FILE SERVICE] Error updating file to github: {e}")
+            raise InternalServerException("[FILE SERVICE] Failed to update file to github") from e
     
     # delete file
     async def delete_file(self, file_path: str) -> bool:

--- a/tool/backend/src/services/github_file_service.py
+++ b/tool/backend/src/services/github_file_service.py
@@ -135,7 +135,7 @@ class GithubFileService:
             contents = self.repository.get_contents(file_path, ref=self.branch)
             self.repository.delete_file(
                 path=file_path,
-                message=f"Rollback: remove orphaned file {file_path}",
+                message=f"Remove file {file_path}",
                 sha=contents.sha,
                 branch=self.branch
             )
@@ -175,5 +175,22 @@ class GithubFileService:
             return True
         except GithubException as e:
             logger.error(f"[FILE SERVICE] Compensating transaction failed — could not restore {template_id}.md: {e}")
+            return False
+
+    # recreate file
+    async def recreate_file(self, template_id: uuid.UUID, content: bytes) -> bool:
+        """Recreates a file that was previously deleted. Used as a compensating transaction."""
+        try:
+            file_path = f"rti-templates/{template_id}.md"
+            self.repository.create_file(
+                path=file_path,
+                message=f"Recreate file {template_id}.md",
+                content=content,
+                branch=self.branch
+            )
+            logger.info(f"[FILE SERVICE] Compensating transaction: recreated {file_path} on github")
+            return True
+        except GithubException as e:
+            logger.error(f"[FILE SERVICE] Compensating transaction failed — could not recreate {template_id}.md: {e}")
             return False
 

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import select, func, Session
 from src.core.exceptions import InternalServerException, BadRequestException, NotFoundException, ConflictException
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +94,18 @@ class RTITemplateService:
             uploaded_file_path: str | None = None  # tracks successful upload for compensating transaction
 
             # 1. upload the file
-            response = await self.file_service.upload_file(template_id=unique_id, file=template_request.file)
+            if template_request.file.content_type != "text/markdown":
+                raise BadRequestException(f'{template_request.file.content_type} is not allowed')
+            
+            content = await template_request.file.read()
+            _, ext = os.path.splitext(template_request.file.filename)
+            file_path = f"rti-templates/{unique_id}{ext}"
+
+            response = await self.file_service.create_file(
+                file_path=file_path, 
+                content=content,
+                message=f"Upload file {template_request.file.filename}"
+            )
 
             relative_path = response.get("relative_path", "")
             absolute_path = response.get("absolute_path", "")
@@ -149,10 +161,22 @@ class RTITemplateService:
         try:
             # update the file if provided
             if template_request.file:
-                # fetch old content for compensating transaction
-                old_file_data = await self.file_service.get_file(rti_template.id)
+                if template_request.file.content_type != "text/markdown":
+                    raise BadRequestException(f'{template_request.file.content_type} is not allowed')
+                
+                content = await template_request.file.read()
+                _, ext = os.path.splitext(template_request.file.filename)
+                file_path = f"rti-templates/{rti_template.id}{ext}"
 
-                response = await self.file_service.update_file(rti_template.id, template_request.file)
+                # fetch old content for compensating transaction
+                old_file_data = await self.file_service.get_file(file_path)
+
+                response = await self.file_service.update_file(
+                    file_path=file_path, 
+                    content=content, 
+                    sha=old_file_data["sha"],
+                    message=f"Update content of {template_request.file.filename}"
+                )
                 
                 relative_path = response.get("relative_path", "")
                 if not relative_path:
@@ -180,12 +204,17 @@ class RTITemplateService:
 
             # rollback the file update if it was successful but DB commit failed
             if old_file_data:
-                current_file_data = await self.file_service.get_file(rti_template.id)
-                await self.file_service.restore_file(
-                    template_id=rti_template.id,
-                    content=old_file_data["content"],
-                    sha=current_file_data["sha"]
-                )
+                current_file_data = await self.file_service.get_file(file_path)
+                try:
+                    await self.file_service.update_file(
+                        file_path=file_path,
+                        content=old_file_data["content"],
+                        sha=current_file_data["sha"],
+                        message=f"Rollback: restore previous version of {file_path}"
+                    )
+                    logger.info(f"[RTI SERVICE] Compensating transaction: restored {file_path} on github")
+                except Exception as ex:
+                    logger.error(f"[RTI SERVICE] Compensating transaction failed — could not restore {file_path}: {ex}")
 
             logger.error(f"[RTI SERVICE] Error updating RTI template: {e}")
             raise InternalServerException(f"[RTI SERVICE] Failed to update RTI template: {e}") from e
@@ -212,7 +241,7 @@ class RTITemplateService:
        
         try:
             if file_path:
-                old_file_data = await self.file_service.get_file(rti_template.id)
+                old_file_data = await self.file_service.get_file(file_path)
 
             # Delete file from GitHub
             if file_path:
@@ -226,7 +255,15 @@ class RTITemplateService:
         except IntegrityError:
             self.session.rollback()
             if old_file_data:
-                await self.file_service.recreate_file(template_id=target_id, content=old_file_data["content"])
+                try:
+                    await self.file_service.create_file(
+                        file_path=file_path,
+                        content=old_file_data["content"],
+                        message=f"Recreate file {file_path}"
+                    )
+                    logger.info(f"[RTI SERVICE] Compensating transaction: recreated {file_path} on github")
+                except Exception as ex:
+                    logger.error(f"[RTI SERVICE] Compensating transaction failed — could not recreate {file_path}: {ex}")
             raise ConflictException("Cannot delete RTI Template because it is used in existing RTI Requests.")
 
         except (BadRequestException, NotFoundException, ConflictException):
@@ -234,7 +271,15 @@ class RTITemplateService:
         except Exception as e:
             self.session.rollback()
             if old_file_data:
-                await self.file_service.recreate_file(template_id=target_id, content=old_file_data["content"])
+                try:
+                    await self.file_service.create_file(
+                        file_path=file_path,
+                        content=old_file_data["content"],
+                        message=f"Recreate file {file_path}"
+                    )
+                    logger.info(f"[RTI SERVICE] Compensating transaction: recreated {file_path} on github")
+                except Exception as ex:
+                    logger.error(f"[RTI SERVICE] Compensating transaction failed — could not recreate {file_path}: {ex}")
             logger.error(f"[RTI SERVICE] Error deleting RTI template: {e}")
             raise InternalServerException(f"Failed to delete RTI template: {e}") from e
 

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -1,10 +1,12 @@
-from uuid import uuid4
+from uuid import UUID, uuid4
 from src.services.github_file_service import GithubFileService
 from src.models import RTITemplate, PaginationModel
-from src.models.response_models import RTITemplateListResponse, RTITemplateResponse, RTITemplateRequest
+from src.models.response_models import RTITemplateListResponse, RTITemplateResponse
+from src.models.request_models import RTITemplateRequest
 from sqlmodel import select, func, Session
-from src.core.exceptions import InternalServerException, BadRequestException
+from src.core.exceptions import InternalServerException, BadRequestException, NotFoundException
 import logging
+import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -99,4 +101,56 @@ class RTITemplateService:
                 await self.file_service.delete_file(file_path=uploaded_file_path)
             logger.error(f"[RTI SERVICE] Error creating RTI template: {e}")
             raise InternalServerException(f"[RTI SERVICE] Failed to create RTI template: {e}") from e
+
+    # API
+    async def update_rti_template(
+        self,
+        *,
+        template_request: RTITemplateRequest
+    ) -> RTITemplateResponse:
+        # fetch the record from the table
+        try:
+            target_id = UUID(template_request.id) if isinstance(template_request.id, str) else template_request.id
+        except ValueError:
+            raise BadRequestException(f"Invalid UUID format: {template_request.id}")
+
+        rti_template = self.session.get(RTITemplate, target_id)
+
+        if not rti_template:
+            raise NotFoundException(f"RTI Template with id {template_request.id} not found.")
+
+        try:
+            # update the file if provided
+            if template_request.file:
+                response = await self.file_service.update_file(rti_template.id, template_request.file)
+                
+                relative_path = response.get("relative_path", "")
+                if not relative_path:
+                    raise InternalServerException("[RTI SERVICE] Invalid path response from file service")
+
+                rti_template.file = relative_path
+
+            if template_request.title:
+                rti_template.title = template_request.title
+            
+            if template_request.description:
+                rti_template.description = template_request.description
+
+            # add the last update timestamp
+            rti_template.updated_at = datetime.datetime.now(datetime.timezone.utc)
+            
+            # commit the changes to db
+            self.session.add(rti_template)
+            self.session.commit()
+            self.session.refresh(rti_template)
+
+            return RTITemplateResponse.model_validate(rti_template)
+
+        except (InternalServerException, BadRequestException, NotFoundException):
+            raise
+        except Exception as e:
+            self.session.rollback()
+            logger.error(f"[RTI SERVICE] Error updating RTI template: {e}")
+            raise InternalServerException(f"[RTI SERVICE] Failed to update RTI template: {e}") from e
+            
 

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -137,6 +137,10 @@ class RTITemplateService:
             # remove the orphaned file from GitHub if the DB commit failed
             if uploaded_file_path:
                 await self.file_service.delete_file(file_path=uploaded_file_path)
+            if isinstance(e, IntegrityError):
+                logger.error(f"[RTI SERVICE] Duplicate title error creating RTI template: {e}")
+                raise ConflictException("RTI Template with this title already exists.") from e
+
             logger.error(f"[RTI SERVICE] Error creating RTI template: {e}")
             raise InternalServerException(f"[RTI SERVICE] Failed to create RTI template: {e}") from e
 
@@ -197,7 +201,7 @@ class RTITemplateService:
 
             return RTITemplateResponse.model_validate(rti_template)
 
-        except (InternalServerException, BadRequestException, NotFoundException):
+        except (InternalServerException, BadRequestException, NotFoundException, ConflictException):
             raise
         except Exception as e:
             self.session.rollback()
@@ -215,6 +219,10 @@ class RTITemplateService:
                     logger.info(f"[RTI SERVICE] Compensating transaction: restored {file_path} on github")
                 except Exception as ex:
                     logger.error(f"[RTI SERVICE] Compensating transaction failed — could not restore {file_path}: {ex}")
+
+            if isinstance(e, IntegrityError):
+                logger.error(f"[RTI SERVICE] Duplicate title error updating RTI template: {e}")
+                raise ConflictException("RTI Template with this title already exists.") from e
 
             logger.error(f"[RTI SERVICE] Error updating RTI template: {e}")
             raise InternalServerException(f"[RTI SERVICE] Failed to update RTI template: {e}") from e

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from uuid import UUID, uuid4
 from src.services.github_file_service import GithubFileService
 from src.models import RTITemplate, PaginationModel
@@ -119,9 +120,13 @@ class RTITemplateService:
         if not rti_template:
             raise NotFoundException(f"RTI Template with id {template_request.id} not found.")
 
+        old_file_data: Dict | None = None
         try:
             # update the file if provided
             if template_request.file:
+                # fetch old content for compensating transaction
+                old_file_data = await self.file_service.get_file(rti_template.id)
+
                 response = await self.file_service.update_file(rti_template.id, template_request.file)
                 
                 relative_path = response.get("relative_path", "")
@@ -147,6 +152,16 @@ class RTITemplateService:
             raise
         except Exception as e:
             self.session.rollback()
+
+            # rollback the file update if it was successful but DB commit failed
+            if old_file_data:
+                current_file_data = await self.file_service.get_file(rti_template.id)
+                await self.file_service.restore_file(
+                    template_id=rti_template.id,
+                    content=old_file_data["content"],
+                    sha=current_file_data["sha"]
+                )
+
             logger.error(f"[RTI SERVICE] Error updating RTI template: {e}")
             raise InternalServerException(f"[RTI SERVICE] Failed to update RTI template: {e}") from e
             

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -4,10 +4,10 @@ from src.services.github_file_service import GithubFileService
 from src.models import RTITemplate, PaginationModel
 from src.models.response_models import RTITemplateListResponse, RTITemplateResponse
 from src.models.request_models import RTITemplateRequest
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import select, func, Session
-from src.core.exceptions import InternalServerException, BadRequestException, NotFoundException
+from src.core.exceptions import InternalServerException, BadRequestException, NotFoundException, ConflictException
 import logging
-import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -164,5 +164,67 @@ class RTITemplateService:
 
             logger.error(f"[RTI SERVICE] Error updating RTI template: {e}")
             raise InternalServerException(f"[RTI SERVICE] Failed to update RTI template: {e}") from e
+
+     # API
+    async def delete_rti_template(
+        self,
+        *,
+        template_id,
+    ) -> Dict:
+        try:
+            # 1. Resolve ID
+            try:
+                target_id = UUID(template_id) if isinstance(template_id, str) else template_id
+            except ValueError:
+                raise BadRequestException(f"Invalid UUID format: {template_id}")
+
+            # 2. Fetch the record
+            rti_template = self.session.get(RTITemplate, target_id)
+            if not rti_template:
+                raise NotFoundException(f"RTI Template with id {template_id} not found.")
+
+            file_path = rti_template.file
+            old_file_data: Dict | None = None
+
+            try:
+                # 3. Fetch file content for potential rollback
+                if file_path:
+                    old_file_data = await self.file_service.get_file(rti_template.id)
+
+                # 4. Delete file from GitHub
+                if file_path:
+                    await self.file_service.delete_file(file_path=file_path)
+
+                # 5. Delete record from DB
+                self.session.delete(rti_template)
+                self.session.commit()
+
+                return {"message": "RTI Template deleted successfully"}
+
+            except IntegrityError:
+                self.session.rollback()
+                # Rollback: Recreate the file if it was deleted
+                if old_file_data:
+                    await self.file_service.recreate_file(
+                        template_id=target_id,
+                        content=old_file_data["content"]
+                    )
+                raise ConflictException("Cannot delete RTI Template because it is used in existing RTI Requests.")
+            except Exception as e:
+                self.session.rollback()
+                # Rollback: Recreate the file if it was deleted
+                if old_file_data:
+                    await self.file_service.recreate_file(
+                        template_id=target_id,
+                        content=old_file_data["content"]
+                    )
+                logger.error(f"[RTI SERVICE] Error deleting RTI template: {e}")
+                raise InternalServerException(f"[RTI SERVICE] Failed to delete RTI template: {e}") from e
+
+        except (BadRequestException, NotFoundException, ConflictException):
+            raise
+        except Exception as e:
+            logger.error(f"[RTI SERVICE] Error in delete operation: {e}")
+            raise InternalServerException(f"[RTI SERVICE] Failed to process delete request: {e}") from e
             
 

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -99,6 +99,10 @@ class RTITemplateService:
             
             content = await template_request.file.read()
             _, ext = os.path.splitext(template_request.file.filename)
+
+            if not ext:
+                raise BadRequestException(f"{template_request.file.filename} doesn't have any file extension")
+                
             file_path = f"rti-templates/{unique_id}{ext}"
 
             response = await self.file_service.create_file(
@@ -169,11 +173,12 @@ class RTITemplateService:
                     raise BadRequestException(f'{template_request.file.content_type} is not allowed')
                 
                 content = await template_request.file.read()
-                _, ext = os.path.splitext(template_request.file.filename)
-                file_path = f"rti-templates/{rti_template.id}{ext}"
+                
+                # Use the existing path from the DB to ensure we update the correct file
+                file_path = rti_template.file
 
                 # fetch old content for compensating transaction
-                old_file_data = await self.file_service.get_file(file_path)
+                old_file_data = await self.file_service.read_file(file_path)
 
                 response = await self.file_service.update_file(
                     file_path=file_path, 
@@ -208,7 +213,7 @@ class RTITemplateService:
 
             # rollback the file update if it was successful but DB commit failed
             if old_file_data:
-                current_file_data = await self.file_service.get_file(file_path)
+                current_file_data = await self.file_service.read_file(file_path)
                 try:
                     await self.file_service.update_file(
                         file_path=file_path,
@@ -249,7 +254,7 @@ class RTITemplateService:
        
         try:
             if file_path:
-                old_file_data = await self.file_service.get_file(file_path)
+                old_file_data = await self.file_service.read_file(file_path)
 
             # Delete file from GitHub
             if file_path:

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -56,6 +56,31 @@ class RTITemplateService:
             raise InternalServerException("Failed to fetch RTI templates from database.") from e
 
     # API
+    def get_rti_template_by_id(
+        self,
+        *,
+        template_id
+    ) -> RTITemplateResponse:
+        try:
+            try:
+                target_id = UUID(template_id) if isinstance(template_id, str) else template_id
+            except ValueError:
+                raise BadRequestException(f"Invalid UUID format: {template_id}")
+
+            rti_template = self.session.get(RTITemplate, target_id)
+
+            if not rti_template:
+                raise NotFoundException(f"RTI Template with id {template_id} not found.")
+
+            return RTITemplateResponse.model_validate(rti_template)
+
+        except (BadRequestException, NotFoundException):
+            raise
+        except Exception as e:
+            logger.error(f"[RTI SERVICE] Error reading RTI template: {e}")
+            raise InternalServerException(f"Failed to read RTI template: {e}") from e
+
+    # API
     async def create_rti_template(
         self,
         *,
@@ -206,7 +231,6 @@ class RTITemplateService:
 
         except (BadRequestException, NotFoundException, ConflictException):
             raise
-
         except Exception as e:
             self.session.rollback()
             if old_file_data:

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -136,9 +136,6 @@ class RTITemplateService:
             if template_request.description:
                 rti_template.description = template_request.description
 
-            # add the last update timestamp
-            rti_template.updated_at = datetime.datetime.now(datetime.timezone.utc)
-            
             # commit the changes to db
             self.session.add(rti_template)
             self.session.commit()

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -215,5 +215,3 @@ class RTITemplateService:
             raise InternalServerException(f"Failed to delete RTI template: {e}") from e
 
 
-            
-

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -171,60 +171,49 @@ class RTITemplateService:
         *,
         template_id,
     ) -> Dict:
+
         try:
-            # 1. Resolve ID
-            try:
-                target_id = UUID(template_id) if isinstance(template_id, str) else template_id
-            except ValueError:
-                raise BadRequestException(f"Invalid UUID format: {template_id}")
+            target_id = UUID(template_id) if isinstance(template_id, str) else template_id
+        except ValueError:
+            raise BadRequestException(f"Invalid UUID format: {template_id}")
 
-            # 2. Fetch the record
-            rti_template = self.session.get(RTITemplate, target_id)
-            if not rti_template:
-                raise NotFoundException(f"RTI Template with id {template_id} not found.")
+        rti_template = self.session.get(RTITemplate, target_id)
 
-            file_path = rti_template.file
-            old_file_data: Dict | None = None
+        if not rti_template:
+            raise NotFoundException(f"RTI Template with id {template_id} not found.")
 
-            try:
-                # 3. Fetch file content for potential rollback
-                if file_path:
-                    old_file_data = await self.file_service.get_file(rti_template.id)
+        file_path = rti_template.file
+        old_file_data = None
+       
+        try:
+            if file_path:
+                old_file_data = await self.file_service.get_file(rti_template.id)
 
-                # 4. Delete file from GitHub
-                if file_path:
-                    await self.file_service.delete_file(file_path=file_path)
+            # Delete file from GitHub
+            if file_path:
+                await self.file_service.delete_file(file_path=file_path)
 
-                # 5. Delete record from DB
-                self.session.delete(rti_template)
-                self.session.commit()
+            # Delete record from DB
+            self.session.delete(rti_template)
+            self.session.commit()
+            return None
 
-                return {"message": "RTI Template deleted successfully"}
-
-            except IntegrityError:
-                self.session.rollback()
-                # Rollback: Recreate the file if it was deleted
-                if old_file_data:
-                    await self.file_service.recreate_file(
-                        template_id=target_id,
-                        content=old_file_data["content"]
-                    )
-                raise ConflictException("Cannot delete RTI Template because it is used in existing RTI Requests.")
-            except Exception as e:
-                self.session.rollback()
-                # Rollback: Recreate the file if it was deleted
-                if old_file_data:
-                    await self.file_service.recreate_file(
-                        template_id=target_id,
-                        content=old_file_data["content"]
-                    )
-                logger.error(f"[RTI SERVICE] Error deleting RTI template: {e}")
-                raise InternalServerException(f"[RTI SERVICE] Failed to delete RTI template: {e}") from e
+        except IntegrityError:
+            self.session.rollback()
+            if old_file_data:
+                await self.file_service.recreate_file(template_id=target_id, content=old_file_data["content"])
+            raise ConflictException("Cannot delete RTI Template because it is used in existing RTI Requests.")
 
         except (BadRequestException, NotFoundException, ConflictException):
             raise
+
         except Exception as e:
-            logger.error(f"[RTI SERVICE] Error in delete operation: {e}")
-            raise InternalServerException(f"[RTI SERVICE] Failed to process delete request: {e}") from e
+            self.session.rollback()
+            if old_file_data:
+                await self.file_service.recreate_file(template_id=target_id, content=old_file_data["content"])
+            logger.error(f"[RTI SERVICE] Error deleting RTI template: {e}")
+            raise InternalServerException(f"Failed to delete RTI template: {e}") from e
+
+
             
 

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -55,7 +55,7 @@ def patch_http_client_session():
 
 # fixtures for RTI Templates
 @pytest.fixture
-def in_memory_db():
+def rti_template_db():
     """Create an in-memory SQLite DB and provide a fresh session with test data."""
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
@@ -139,11 +139,11 @@ def make_file_service():
     ) -> MagicMock:
         file_service = MagicMock()
         
-        # mock upload_file
+        # mock create_file
         if upload_side_effect:
-            file_service.upload_file = AsyncMock(side_effect=upload_side_effect)
+            file_service.create_file = AsyncMock(side_effect=upload_side_effect)
         else:
-            file_service.upload_file = AsyncMock(return_value={
+            file_service.create_file = AsyncMock(return_value={
                 "relative_path": relative_path,
                 "absolute_path": absolute_path,
             })
@@ -165,8 +165,7 @@ def make_file_service():
             "sha": "old-sha"
         })
         
-        # mock restore_file
-        file_service.restore_file = AsyncMock(return_value=True)
+        # remove restore_file/recreate_file mocks since they are deleted
 
         return file_service
 

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -159,8 +159,8 @@ def make_file_service():
 
         file_service.delete_file = AsyncMock(return_value=delete_return)
         
-        # mock get_file
-        file_service.get_file = AsyncMock(return_value={
+        # mock read_file
+        file_service.read_file = AsyncMock(return_value={
             "content": b"# Old Content",
             "sha": "old-sha"
         })

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -134,19 +134,40 @@ def make_file_service():
         relative_path: str = "rti-templates/test-uuid.md",
         absolute_path: str = "https://github.com/org/repo/blob/main/rti-templates/test-uuid.md",
         upload_side_effect=None,
+        update_side_effect=None,
         delete_return: bool = True,
     ) -> MagicMock:
         file_service = MagicMock()
+        
+        # mock upload_file
         if upload_side_effect:
             file_service.upload_file = AsyncMock(side_effect=upload_side_effect)
         else:
-            file_service.upload_file = AsyncMock(
-                return_value={
-                    "relative_path": relative_path,
-                    "absolute_path": absolute_path,
-                }
-            )
+            file_service.upload_file = AsyncMock(return_value={
+                "relative_path": relative_path,
+                "absolute_path": absolute_path,
+            })
+            
+        # mock update_file
+        if update_side_effect:
+            file_service.update_file = AsyncMock(side_effect=update_side_effect)
+        else:
+            file_service.update_file = AsyncMock(return_value={
+                "relative_path": relative_path,
+                "absolute_path": absolute_path,
+            })
+
         file_service.delete_file = AsyncMock(return_value=delete_return)
+        
+        # mock get_file
+        file_service.get_file = AsyncMock(return_value={
+            "content": b"# Old Content",
+            "sha": "old-sha"
+        })
+        
+        # mock restore_file
+        file_service.restore_file = AsyncMock(return_value=True)
+
         return file_service
 
     return _factory
@@ -159,6 +180,7 @@ def make_template_request():
     def _factory(
         title: str = "Test Template",
         description: str = "A test description",
+        id: str = None
     ) -> MagicMock:
         mock_upload = AsyncMock()
         mock_upload.content_type = "text/markdown"
@@ -166,6 +188,7 @@ def make_template_request():
         mock_upload.read = AsyncMock(return_value=b"# Test")
 
         request = MagicMock(spec=RTITemplateRequest)
+        request.id = id
         request.title = title
         request.description = description
         request.file = mock_upload

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -5,7 +5,7 @@ from aiohttp import ClientError
 from datetime import datetime, timezone, timedelta
 from sqlmodel import SQLModel, Session, create_engine
 from src.models import RTITemplate, Institution, Position
-from src.models.response_models import RTITemplateRequest
+from src.models.request_models import RTITemplateRequest
 from src.services.github_file_service import GithubFileService
 from fastapi import UploadFile
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock

--- a/tool/backend/test/test_github_file_service.py
+++ b/tool/backend/test/test_github_file_service.py
@@ -237,10 +237,10 @@ def test_get_github_file_path_builds_correct_url():
     )
     assert url == "https://github.com/org/repo/blob/main/rti-templates/abc.md"
 
-# get_file tests
+# read_file tests
 @pytest.mark.asyncio
 async def test_get_file_success(make_github_content_file):
-    """get_file returns decoded content and SHA from the GitHub API."""
+    """read_file returns decoded content and SHA from the GitHub API."""
     file_path = f"rti-templates/test-file.md"
     expected_content = b"# Content"
     expected_sha = "sha123"
@@ -251,7 +251,7 @@ async def test_get_file_success(make_github_content_file):
 
     service = _make_service(get_contents_return=contents)
 
-    result = await service.get_file(file_path=file_path)
+    result = await service.read_file(file_path=file_path)
 
     assert result["content"] == expected_content
     assert result["sha"] == expected_sha
@@ -259,9 +259,9 @@ async def test_get_file_success(make_github_content_file):
 
 @pytest.mark.asyncio
 async def test_get_file_raises_internal_exception_on_github_error():
-    """get_file wraps GitHub API errors in InternalServerException."""
+    """read_file wraps GitHub API errors in InternalServerException."""
     service = _make_service(get_contents_side_effect=GithubException(404, "Not Found"))
 
     with pytest.raises(InternalServerException):
-        await service.get_file(file_path="rti-templates/test.md")
+        await service.read_file(file_path="rti-templates/test.md")
 

--- a/tool/backend/test/test_github_file_service.py
+++ b/tool/backend/test/test_github_file_service.py
@@ -14,6 +14,8 @@ def _make_service(
     get_contents_side_effect=None,
     delete_file_return=None,
     delete_file_side_effect=None,
+    update_file_return=None,
+    update_file_side_effect=None,
 ) -> GithubFileService:
     """Builds a GithubFileService instance by mocking GitHub to avoid actual network calls."""
     with patch("src.services.github_file_service.Github") as MockGithub:
@@ -40,6 +42,10 @@ def _make_service(
             service.repository.delete_file.side_effect = delete_file_side_effect
         elif delete_file_return is not None:
             service.repository.delete_file.return_value = delete_file_return
+        if update_file_side_effect:
+            service.repository.update_file.side_effect = update_file_side_effect
+        elif update_file_return is not None:
+            service.repository.update_file.return_value = update_file_return
             
         return service
 
@@ -133,6 +139,89 @@ async def test_upload_file_returns_empty_paths_when_content_file_is_none(make_up
     service = _make_service(create_file_return={"content": None})
 
     result = await service.upload_file(template_id=uuid.uuid4(), file=make_upload_file())
+
+    assert result["relative_path"] == ""
+    assert result["absolute_path"] == ""
+
+
+# update_file tests
+@pytest.mark.asyncio
+async def test_update_file_success(make_upload_file, make_github_content_file):
+    """update_file returns correct relative and absolute paths on success."""
+    template_id = uuid.uuid4()
+    expected_relative = f"rti-templates/{template_id}.md"
+    expected_absolute = f"https://github.com/test-repo/blob/main/{expected_relative}"
+
+    content_file = make_github_content_file(expected_relative)
+    # mock get_contents for update call
+    # update_file returns a dict with "content" in PyGithub
+    service = _make_service(
+        get_contents_return=MagicMock(sha="old-sha"),
+        update_file_return={"content": content_file}
+    )
+
+    result = await service.update_file(template_id=template_id, file=make_upload_file())
+
+    assert result["relative_path"] == expected_relative
+    assert result["absolute_path"] == expected_absolute
+    service.repository.update_file.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_file_calls_update_file_with_correct_args(make_upload_file, make_github_content_file):
+    """update_file passes correct path, content, sha and branch to GitHub API."""
+    template_id = uuid.uuid4()
+    file_content = b"# Updated RTI"
+    expected_path = f"rti-templates/{template_id}.md"
+    expected_sha = "abc123sha"
+
+    content_file = make_github_content_file(expected_path)
+    existing_file = MagicMock()
+    existing_file.sha = expected_sha
+
+    service = _make_service(
+        get_contents_return=existing_file,
+        update_file_return={"content": content_file}
+    )
+
+    await service.update_file(template_id=template_id, file=make_upload_file(content=file_content))
+
+    service.repository.update_file.assert_called_once()
+    call_kwargs = service.repository.update_file.call_args.kwargs
+    assert call_kwargs["path"] == expected_path
+    assert call_kwargs["content"] == file_content
+    assert call_kwargs["sha"] == expected_sha
+    assert call_kwargs["branch"] == "main"
+
+@pytest.mark.asyncio
+async def test_update_file_rejects_disallowed_content_type(make_upload_file):
+    """update_file raises BadRequestException for non-markdown files."""
+    service = _make_service()
+    upload = make_upload_file(content_type="text/html", filename="page.html")
+
+    with pytest.raises(BadRequestException):
+        await service.update_file(template_id=uuid.uuid4(), file=upload)
+
+@pytest.mark.asyncio
+async def test_update_file_raises_internal_exception_on_github_error(make_upload_file):
+    """update_file wraps GitHub API errors in InternalServerException."""
+    service = _make_service(
+        get_contents_return=MagicMock(sha="sha"),
+        update_file_side_effect=GithubException(500, "Update failed")
+    )
+
+    with pytest.raises(InternalServerException):
+        await service.update_file(template_id=uuid.uuid4(), file=make_upload_file())
+
+@pytest.mark.asyncio
+async def test_update_file_returns_empty_paths_when_content_file_is_none(make_upload_file):
+    """update_file returns empty strings when GitHub response has no content object."""
+    service = _make_service(
+        get_contents_return=MagicMock(sha="sha"),
+        update_file_return={"content": None}
+    )
+
+    result = await service.update_file(template_id=uuid.uuid4(), file=make_upload_file())
 
     assert result["relative_path"] == ""
     assert result["absolute_path"] == ""

--- a/tool/backend/test/test_github_file_service.py
+++ b/tool/backend/test/test_github_file_service.py
@@ -242,7 +242,7 @@ async def test_delete_file_success(make_github_content_file):
     service.repository.get_contents.assert_called_once_with(file_path, ref="main")
     service.repository.delete_file.assert_called_once_with(
         path=file_path,
-        message=f"Rollback: remove orphaned file {file_path}",
+        message=f"Remove file {file_path}",
         sha="deadbeef",
         branch="main"
     )

--- a/tool/backend/test/test_github_file_service.py
+++ b/tool/backend/test/test_github_file_service.py
@@ -61,84 +61,53 @@ def test_file_service_initialization():
         assert hasattr(service, "github")
         assert hasattr(service, "repository")
 
-# upload_file tests
+# create_file tests
 @pytest.mark.asyncio
-async def test_upload_file_success(make_upload_file, make_github_content_file):
-    """upload_file returns correct relative and absolute paths on success."""
-    template_id = uuid.uuid4()
-    expected_relative = f"rti-templates/{template_id}.md"
-    expected_absolute = f"https://github.com/test-repo/blob/main/{expected_relative}"
+async def test_create_file_success(make_github_content_file):
+    """create_file returns correct relative and absolute paths on success."""
+    file_path = "rti-templates/test-file.md"
+    expected_absolute = f"https://github.com/test-repo/blob/main/{file_path}"
 
-    content_file = make_github_content_file(expected_relative)
+    content_file = make_github_content_file(file_path)
     service = _make_service(create_file_return={"content": content_file})
 
-    result = await service.upload_file(template_id=template_id, file=make_upload_file())
+    result = await service.create_file(file_path=file_path, content=b"content")
 
-    assert result["relative_path"] == expected_relative
+    assert result["relative_path"] == file_path
     assert result["absolute_path"] == expected_absolute
     service.repository.create_file.assert_called_once()
 
 @pytest.mark.asyncio
-async def test_upload_file_calls_create_file_with_correct_args(make_upload_file, make_github_content_file):
-    """upload_file passes the correct path, message, content, and branch to the GitHub API."""
-    template_id = uuid.uuid4()
+async def test_create_file_calls_create_file_with_correct_args(make_github_content_file):
+    """create_file passes the correct path, message, content, and branch to the GitHub API."""
     file_content = b"# RTI Template"
-    expected_path = f"rti-templates/{template_id}.md"
+    expected_path = "rti-templates/test-file.md"
 
     content_file = make_github_content_file(expected_path)
     service = _make_service(create_file_return={"content": content_file})
 
-    await service.upload_file(template_id=template_id, file=make_upload_file(content=file_content))
+    await service.create_file(file_path=expected_path, content=file_content, message="Upload custom file")
 
     call_kwargs = service.repository.create_file.call_args.kwargs
     assert call_kwargs["path"] == expected_path
     assert call_kwargs["content"] == file_content
     assert call_kwargs["branch"] == "main"
-
-# upload_file tests
-@pytest.mark.asyncio
-async def test_upload_file_rejects_disallowed_content_type(make_upload_file):
-    """upload_file raises BadRequestException for non-markdown files."""
-    service = _make_service()
-    upload = make_upload_file(content_type="application/pdf", filename="document.pdf")
-
-    with pytest.raises(BadRequestException):
-        await service.upload_file(template_id=uuid.uuid4(), file=upload)
+    assert call_kwargs["message"] == "Upload custom file"
 
 @pytest.mark.asyncio
-async def test_upload_file_rejects_plain_text(make_upload_file):
-    """upload_file raises BadRequestException for text/plain files."""
-    service = _make_service()
-
-    with pytest.raises(BadRequestException):
-        await service.upload_file(template_id=uuid.uuid4(), file=make_upload_file(content_type="text/plain"))
-
-
-@pytest.mark.asyncio
-async def test_upload_file_bad_request_message_contains_content_type(make_upload_file):
-    """The BadRequestException message includes the rejected content type."""
-    service = _make_service()
-    upload = make_upload_file(content_type="image/png")
-
-    with pytest.raises(BadRequestException) as exc_info:
-        await service.upload_file(template_id=uuid.uuid4(), file=upload)
-
-    assert "image/png" in str(exc_info.value)
-
-@pytest.mark.asyncio
-async def test_upload_file_raises_internal_exception_on_github_error(make_upload_file):
-    """upload_file wraps GitHub API errors in InternalServerException."""
+async def test_create_file_raises_internal_exception_on_github_error():
+    """create_file wraps GitHub API errors in InternalServerException."""
     service = _make_service(create_file_side_effect=GithubException(500, "GitHub API unavailable"))
 
     with pytest.raises(InternalServerException):
-        await service.upload_file(template_id=uuid.uuid4(), file=make_upload_file())
+        await service.create_file(file_path="test.md", content=b"content")
 
 @pytest.mark.asyncio
-async def test_upload_file_returns_empty_paths_when_content_file_is_none(make_upload_file):
-    """upload_file returns empty strings when the GitHub response has no content object."""
+async def test_create_file_returns_empty_paths_when_content_file_is_none():
+    """create_file returns empty strings when the GitHub response has no content object."""
     service = _make_service(create_file_return={"content": None})
 
-    result = await service.upload_file(template_id=uuid.uuid4(), file=make_upload_file())
+    result = await service.create_file(file_path="test.md", content=b"content")
 
     assert result["relative_path"] == ""
     assert result["absolute_path"] == ""
@@ -146,45 +115,31 @@ async def test_upload_file_returns_empty_paths_when_content_file_is_none(make_up
 
 # update_file tests
 @pytest.mark.asyncio
-async def test_update_file_success(make_upload_file, make_github_content_file):
+async def test_update_file_success(make_github_content_file):
     """update_file returns correct relative and absolute paths on success."""
-    template_id = uuid.uuid4()
-    expected_relative = f"rti-templates/{template_id}.md"
-    expected_absolute = f"https://github.com/test-repo/blob/main/{expected_relative}"
+    file_path = "rti-templates/test-file.md"
+    expected_absolute = f"https://github.com/test-repo/blob/main/{file_path}"
 
-    content_file = make_github_content_file(expected_relative)
-    # mock get_contents for update call
-    # update_file returns a dict with "content" in PyGithub
-    service = _make_service(
-        get_contents_return=MagicMock(sha="old-sha"),
-        update_file_return={"content": content_file}
-    )
+    content_file = make_github_content_file(file_path)
+    service = _make_service(update_file_return={"content": content_file})
 
-    result = await service.update_file(template_id=template_id, file=make_upload_file())
+    result = await service.update_file(file_path=file_path, content=b"content", sha="abc123sha")
 
-    assert result["relative_path"] == expected_relative
+    assert result["relative_path"] == file_path
     assert result["absolute_path"] == expected_absolute
     service.repository.update_file.assert_called_once()
 
-
 @pytest.mark.asyncio
-async def test_update_file_calls_update_file_with_correct_args(make_upload_file, make_github_content_file):
+async def test_update_file_calls_update_file_with_correct_args(make_github_content_file):
     """update_file passes correct path, content, sha and branch to GitHub API."""
-    template_id = uuid.uuid4()
     file_content = b"# Updated RTI"
-    expected_path = f"rti-templates/{template_id}.md"
+    expected_path = "rti-templates/test-file.md"
     expected_sha = "abc123sha"
 
     content_file = make_github_content_file(expected_path)
-    existing_file = MagicMock()
-    existing_file.sha = expected_sha
+    service = _make_service(update_file_return={"content": content_file})
 
-    service = _make_service(
-        get_contents_return=existing_file,
-        update_file_return={"content": content_file}
-    )
-
-    await service.update_file(template_id=template_id, file=make_upload_file(content=file_content))
+    await service.update_file(file_path=expected_path, content=file_content, sha=expected_sha, message="Update custom content")
 
     service.repository.update_file.assert_called_once()
     call_kwargs = service.repository.update_file.call_args.kwargs
@@ -192,36 +147,22 @@ async def test_update_file_calls_update_file_with_correct_args(make_upload_file,
     assert call_kwargs["content"] == file_content
     assert call_kwargs["sha"] == expected_sha
     assert call_kwargs["branch"] == "main"
+    assert call_kwargs["message"] == "Update custom content"
 
 @pytest.mark.asyncio
-async def test_update_file_rejects_disallowed_content_type(make_upload_file):
-    """update_file raises BadRequestException for non-markdown files."""
-    service = _make_service()
-    upload = make_upload_file(content_type="text/html", filename="page.html")
-
-    with pytest.raises(BadRequestException):
-        await service.update_file(template_id=uuid.uuid4(), file=upload)
-
-@pytest.mark.asyncio
-async def test_update_file_raises_internal_exception_on_github_error(make_upload_file):
+async def test_update_file_raises_internal_exception_on_github_error():
     """update_file wraps GitHub API errors in InternalServerException."""
-    service = _make_service(
-        get_contents_return=MagicMock(sha="sha"),
-        update_file_side_effect=GithubException(500, "Update failed")
-    )
+    service = _make_service(update_file_side_effect=GithubException(500, "Update failed"))
 
     with pytest.raises(InternalServerException):
-        await service.update_file(template_id=uuid.uuid4(), file=make_upload_file())
+        await service.update_file(file_path="test.md", content=b"content", sha="sha")
 
 @pytest.mark.asyncio
-async def test_update_file_returns_empty_paths_when_content_file_is_none(make_upload_file):
+async def test_update_file_returns_empty_paths_when_content_file_is_none():
     """update_file returns empty strings when GitHub response has no content object."""
-    service = _make_service(
-        get_contents_return=MagicMock(sha="sha"),
-        update_file_return={"content": None}
-    )
+    service = _make_service(update_file_return={"content": None})
 
-    result = await service.update_file(template_id=uuid.uuid4(), file=make_upload_file())
+    result = await service.update_file(file_path="test.md", content=b"content", sha="sha")
 
     assert result["relative_path"] == ""
     assert result["absolute_path"] == ""
@@ -300,8 +241,7 @@ def test_get_github_file_path_builds_correct_url():
 @pytest.mark.asyncio
 async def test_get_file_success(make_github_content_file):
     """get_file returns decoded content and SHA from the GitHub API."""
-    template_id = uuid.uuid4()
-    file_path = f"rti-templates/{template_id}.md"
+    file_path = f"rti-templates/test-file.md"
     expected_content = b"# Content"
     expected_sha = "sha123"
 
@@ -311,7 +251,7 @@ async def test_get_file_success(make_github_content_file):
 
     service = _make_service(get_contents_return=contents)
 
-    result = await service.get_file(template_id=template_id)
+    result = await service.get_file(file_path=file_path)
 
     assert result["content"] == expected_content
     assert result["sha"] == expected_sha
@@ -323,65 +263,5 @@ async def test_get_file_raises_internal_exception_on_github_error():
     service = _make_service(get_contents_side_effect=GithubException(404, "Not Found"))
 
     with pytest.raises(InternalServerException):
-        await service.get_file(template_id=uuid.uuid4())
-
-# restore_file tests
-@pytest.mark.asyncio
-async def test_restore_file_success():
-    """restore_file returns True and calls update_file on the GitHub repository."""
-    template_id = uuid.uuid4()
-    content = b"# Restored Content"
-    sha = "old-sha"
-    file_path = f"rti-templates/{template_id}.md"
-
-    service = _make_service(update_file_return={"content": MagicMock()})
-
-    result = await service.restore_file(template_id=template_id, content=content, sha=sha)
-
-    assert result is True
-    service.repository.update_file.assert_called_once_with(
-        path=file_path,
-        message=f"Rollback: restore previous version of {template_id}.md",
-        content=content,
-        sha=sha,
-        branch="main"
-    )
-
-@pytest.mark.asyncio
-async def test_restore_file_returns_false_on_github_error():
-    """restore_file returns False when the GitHub API fails."""
-    service = _make_service(update_file_side_effect=GithubException(500, "Restore failed"))
-
-    result = await service.restore_file(template_id=uuid.uuid4(), content=b"", sha="sha")
-
-    assert result is False
-
-# recreate_file tests
-@pytest.mark.asyncio
-async def test_recreate_file_success():
-    """recreate_file returns True and calls create_file on the GitHub repository."""
-    template_id = uuid.uuid4()
-    content = b"# Recreated Content"
-    file_path = f"rti-templates/{template_id}.md"
-
-    service = _make_service(create_file_return={"content": MagicMock()})
-
-    result = await service.recreate_file(template_id=template_id, content=content)
-
-    assert result is True
-    service.repository.create_file.assert_called_once_with(
-        path=file_path,
-        message=f"Recreate file {template_id}.md",
-        content=content,
-        branch="main"
-    )
-
-@pytest.mark.asyncio
-async def test_recreate_file_returns_false_on_github_error():
-    """recreate_file returns False when the GitHub API fails."""
-    service = _make_service(create_file_side_effect=GithubException(500, "Recreate failed"))
-
-    result = await service.recreate_file(template_id=uuid.uuid4(), content=b"")
-
-    assert result is False
+        await service.get_file(file_path="rti-templates/test.md")
 

--- a/tool/backend/test/test_github_file_service.py
+++ b/tool/backend/test/test_github_file_service.py
@@ -296,3 +296,92 @@ def test_get_github_file_path_builds_correct_url():
     )
     assert url == "https://github.com/org/repo/blob/main/rti-templates/abc.md"
 
+# get_file tests
+@pytest.mark.asyncio
+async def test_get_file_success(make_github_content_file):
+    """get_file returns decoded content and SHA from the GitHub API."""
+    template_id = uuid.uuid4()
+    file_path = f"rti-templates/{template_id}.md"
+    expected_content = b"# Content"
+    expected_sha = "sha123"
+
+    contents = make_github_content_file(file_path)
+    contents.decoded_content = expected_content
+    contents.sha = expected_sha
+
+    service = _make_service(get_contents_return=contents)
+
+    result = await service.get_file(template_id=template_id)
+
+    assert result["content"] == expected_content
+    assert result["sha"] == expected_sha
+    service.repository.get_contents.assert_called_once_with(file_path, ref="main")
+
+@pytest.mark.asyncio
+async def test_get_file_raises_internal_exception_on_github_error():
+    """get_file wraps GitHub API errors in InternalServerException."""
+    service = _make_service(get_contents_side_effect=GithubException(404, "Not Found"))
+
+    with pytest.raises(InternalServerException):
+        await service.get_file(template_id=uuid.uuid4())
+
+# restore_file tests
+@pytest.mark.asyncio
+async def test_restore_file_success():
+    """restore_file returns True and calls update_file on the GitHub repository."""
+    template_id = uuid.uuid4()
+    content = b"# Restored Content"
+    sha = "old-sha"
+    file_path = f"rti-templates/{template_id}.md"
+
+    service = _make_service(update_file_return={"content": MagicMock()})
+
+    result = await service.restore_file(template_id=template_id, content=content, sha=sha)
+
+    assert result is True
+    service.repository.update_file.assert_called_once_with(
+        path=file_path,
+        message=f"Rollback: restore previous version of {template_id}.md",
+        content=content,
+        sha=sha,
+        branch="main"
+    )
+
+@pytest.mark.asyncio
+async def test_restore_file_returns_false_on_github_error():
+    """restore_file returns False when the GitHub API fails."""
+    service = _make_service(update_file_side_effect=GithubException(500, "Restore failed"))
+
+    result = await service.restore_file(template_id=uuid.uuid4(), content=b"", sha="sha")
+
+    assert result is False
+
+# recreate_file tests
+@pytest.mark.asyncio
+async def test_recreate_file_success():
+    """recreate_file returns True and calls create_file on the GitHub repository."""
+    template_id = uuid.uuid4()
+    content = b"# Recreated Content"
+    file_path = f"rti-templates/{template_id}.md"
+
+    service = _make_service(create_file_return={"content": MagicMock()})
+
+    result = await service.recreate_file(template_id=template_id, content=content)
+
+    assert result is True
+    service.repository.create_file.assert_called_once_with(
+        path=file_path,
+        message=f"Recreate file {template_id}.md",
+        content=content,
+        branch="main"
+    )
+
+@pytest.mark.asyncio
+async def test_recreate_file_returns_false_on_github_error():
+    """recreate_file returns False when the GitHub API fails."""
+    service = _make_service(create_file_side_effect=GithubException(500, "Recreate failed"))
+
+    result = await service.recreate_file(template_id=uuid.uuid4(), content=b"")
+
+    assert result is False
+

--- a/tool/backend/test/test_rti_template_service.py
+++ b/tool/backend/test/test_rti_template_service.py
@@ -1,7 +1,6 @@
 # tests/test_rti_template_service.py
 import uuid
 import pytest
-from datetime import datetime
 from unittest.mock import MagicMock, AsyncMock, patch
 from sqlalchemy.exc import OperationalError, IntegrityError
 from src.services.rti_template_service import RTITemplateService
@@ -11,10 +10,10 @@ from sqlmodel import SQLModel, Session, create_engine, select
 from src.models import RTITemplate
 
 @pytest.mark.asyncio
-async def test_get_rti_templates_default(in_memory_db, make_file_service):
+async def test_get_rti_templates_default(rti_template_db, make_file_service):
     absolute_url = "https://github.com/org/repo/blob/main/rti-templates/some-uuid.md"
 
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service(absolute_path=absolute_url))
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service(absolute_path=absolute_url))
     response = service.get_rti_templates()
     
     assert response.pagination.page == 1
@@ -24,10 +23,10 @@ async def test_get_rti_templates_default(in_memory_db, make_file_service):
     assert len(response.data) == 3
 
 @pytest.mark.asyncio
-async def test_get_rti_templates_custom_page(in_memory_db, make_file_service):
+async def test_get_rti_templates_custom_page(rti_template_db, make_file_service):
     absolute_url = "https://github.com/org/repo/blob/main/rti-templates/some-uuid.md"
 
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service(absolute_path=absolute_url))
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service(absolute_path=absolute_url))
     response = service.get_rti_templates(page=2, page_size=2)
     
     assert response.pagination.page == 2
@@ -53,11 +52,11 @@ async def test_get_rti_templates_empty_db(make_file_service):
         assert response.data == []
 
 @pytest.mark.asyncio
-async def test_get_rti_templates_page_out_of_bounds(in_memory_db, make_file_service):
+async def test_get_rti_templates_page_out_of_bounds(rti_template_db, make_file_service):
     """Requesting a page beyond total pages should return empty list."""
     absolute_url = "https://github.com/org/repo/blob/main/rti-templates/some-uuid.md"
 
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service(absolute_path=absolute_url))
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service(absolute_path=absolute_url))
     response = service.get_rti_templates(page=10, page_size=2)
     
     assert response.pagination.page == 10
@@ -66,29 +65,29 @@ async def test_get_rti_templates_page_out_of_bounds(in_memory_db, make_file_serv
     assert response.pagination.totalPages == 2
 
 @pytest.mark.asyncio
-async def test_get_rti_templates_raises_internal_exception(monkeypatch, in_memory_db, make_file_service):
+async def test_get_rti_templates_raises_internal_exception(monkeypatch, rti_template_db, make_file_service):
     """Simulate a database failure and ensure InternalServerException is raised."""
     absolute_url = "https://github.com/org/repo/blob/main/rti-templates/some-uuid.md"
 
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service(absolute_path=absolute_url))
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service(absolute_path=absolute_url))
     
     # Monkeypatch the session.exec to raise an exception
     def fake_exec(*args, **kwargs):
         raise OperationalError("Fake DB failure", None, None)
     
-    monkeypatch.setattr(in_memory_db, "exec", fake_exec)
+    monkeypatch.setattr(rti_template_db, "exec", fake_exec)
     
     with pytest.raises(InternalServerException):
         await service.get_rti_templates()
 
 # create_rti_template tests
 @pytest.mark.asyncio
-async def test_create_rti_template_success(in_memory_db, make_file_service, make_template_request):
+async def test_create_rti_template_success(rti_template_db, make_file_service, make_template_request):
     """Happy path: template is created and returned as RTITemplateResponse."""
     relative_path = "rti-templates/some-uuid.md"
     absolute_url = "https://github.com/org/repo/blob/main/rti-templates/some-uuid.md"
 
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service(relative_path=relative_path, absolute_path=absolute_url))
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service(relative_path=relative_path, absolute_path=absolute_url))
     result = await service.create_rti_template(template_request=make_template_request(title="My RTI", description="Details"))
 
     assert isinstance(result, RTITemplateResponse)
@@ -98,39 +97,39 @@ async def test_create_rti_template_success(in_memory_db, make_file_service, make
     assert isinstance(result.id, uuid.UUID)
 
 @pytest.mark.asyncio
-async def test_create_rti_template_stores_relative_path_in_db(in_memory_db, make_file_service, make_template_request):
+async def test_create_rti_template_stores_relative_path_in_db(rti_template_db, make_file_service, make_template_request):
     """The relative GitHub path is persisted to the database."""
     relative_path = "rti-templates/stored.md"
     absolute_url = "https://github.com/org/repo/blob/main/rti-templates/stored.md"
 
     service = RTITemplateService(
-        session=in_memory_db,
+        session=rti_template_db,
         file_service=make_file_service(relative_path=relative_path, absolute_path=absolute_url),
     )
     result = await service.create_rti_template(template_request=make_template_request(title="Stored URL Test"))
 
-    db_record = in_memory_db.exec(select(RTITemplate).where(RTITemplate.id == result.id)).first()
+    db_record = rti_template_db.exec(select(RTITemplate).where(RTITemplate.id == result.id)).first()
     assert db_record is not None
     assert db_record.file == relative_path
 
 @pytest.mark.asyncio
-async def test_create_rti_template_calls_upload_file(in_memory_db, make_file_service, make_template_request):
-    """upload_file is called exactly once with the generated UUID and UploadFile."""
+async def test_create_rti_template_calls_create_file(rti_template_db, make_file_service, make_template_request):
+    """create_file is called exactly once with the generated UUID path and content."""
     fs = make_file_service()
-    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
     request = make_template_request()
 
     await service.create_rti_template(template_request=request)
 
-    fs.upload_file.assert_called_once()
-    call_kwargs = fs.upload_file.call_args.kwargs
-    assert call_kwargs["file"] is request.file
-    assert isinstance(call_kwargs["template_id"], uuid.UUID)
+    fs.create_file.assert_called_once()
+    call_kwargs = fs.create_file.call_args.kwargs
+    assert call_kwargs["content"] == b"# Test"
+    assert "rti-templates/" in call_kwargs["file_path"]
 
 @pytest.mark.asyncio
-async def test_create_rti_template_without_description(in_memory_db, make_file_service, make_template_request):
+async def test_create_rti_template_without_description(rti_template_db, make_file_service, make_template_request):
     """Optional description can be None without breaking the creation flow."""
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
 
     request = make_template_request(title="No Description")
     request.description = None
@@ -141,10 +140,10 @@ async def test_create_rti_template_without_description(in_memory_db, make_file_s
     assert result.title == "No Description"
 
 @pytest.mark.asyncio
-async def test_create_rti_template_raises_when_relative_path_empty(in_memory_db, make_file_service, make_template_request):
-    """InternalServerException is raised when upload_file returns empty relative_path."""
+async def test_create_rti_template_raises_when_relative_path_empty(rti_template_db, make_file_service, make_template_request):
+    """InternalServerException is raised when create_file returns empty relative_path."""
     service = RTITemplateService(
-        session=in_memory_db,
+        session=rti_template_db,
         file_service=make_file_service(relative_path="", absolute_path="https://example.com/file.md"),
     )
 
@@ -152,10 +151,10 @@ async def test_create_rti_template_raises_when_relative_path_empty(in_memory_db,
         await service.create_rti_template(template_request=make_template_request())
 
 @pytest.mark.asyncio
-async def test_create_rti_template_raises_when_absolute_path_empty(in_memory_db, make_file_service, make_template_request):
-    """InternalServerException is raised when upload_file returns empty absolute_path."""
+async def test_create_rti_template_raises_when_absolute_path_empty(rti_template_db, make_file_service, make_template_request):
+    """InternalServerException is raised when create_file returns empty absolute_path."""
     service = RTITemplateService(
-        session=in_memory_db,
+        session=rti_template_db,
         file_service=make_file_service(relative_path="rti-templates/test.md", absolute_path=""),
     )
 
@@ -163,10 +162,10 @@ async def test_create_rti_template_raises_when_absolute_path_empty(in_memory_db,
         await service.create_rti_template(template_request=make_template_request())
 
 @pytest.mark.asyncio
-async def test_create_rti_template_raises_when_upload_fails(in_memory_db, make_file_service, make_template_request):
+async def test_create_rti_template_raises_when_upload_fails(rti_template_db, make_file_service, make_template_request):
     """InternalServerException propagates when file upload itself raises."""
     service = RTITemplateService(
-        session=in_memory_db,
+        session=rti_template_db,
         file_service=make_file_service(upload_side_effect=InternalServerException("Upload failed")),
     )
 
@@ -174,10 +173,10 @@ async def test_create_rti_template_raises_when_upload_fails(in_memory_db, make_f
         await service.create_rti_template(template_request=make_template_request())
 
 @pytest.mark.asyncio
-async def test_create_rti_template_does_not_call_delete_if_upload_failed(in_memory_db, make_file_service, make_template_request):
+async def test_create_rti_template_does_not_call_delete_if_upload_failed(rti_template_db, make_file_service, make_template_request):
     """delete_file is NOT called when the upload itself fails — nothing to roll back."""
     fs = make_file_service(upload_side_effect=InternalServerException("Upload failed"))
-    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
 
     with pytest.raises(InternalServerException):
         await service.create_rti_template(template_request=make_template_request())
@@ -185,12 +184,12 @@ async def test_create_rti_template_does_not_call_delete_if_upload_failed(in_memo
     fs.delete_file.assert_not_called()
 
 @pytest.mark.asyncio
-async def test_create_rti_template_calls_delete_file_on_db_failure(in_memory_db, monkeypatch, make_file_service, make_template_request):
+async def test_create_rti_template_calls_delete_file_on_db_failure(rti_template_db, monkeypatch, make_file_service, make_template_request):
     """delete_file is called as a compensating transaction when DB commit fails."""
     fs = make_file_service(relative_path="rti-templates/uuid.md")
-    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
 
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=Exception("DB commit error")))
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=Exception("DB commit error")))
 
     with pytest.raises(InternalServerException):
         await service.create_rti_template(template_request=make_template_request())
@@ -198,13 +197,13 @@ async def test_create_rti_template_calls_delete_file_on_db_failure(in_memory_db,
     fs.delete_file.assert_called_once_with(file_path="rti-templates/uuid.md")
 
 @pytest.mark.asyncio
-async def test_create_rti_template_rolls_back_session_on_failure(in_memory_db, monkeypatch, make_file_service, make_template_request):
+async def test_create_rti_template_rolls_back_session_on_failure(rti_template_db, monkeypatch, make_file_service, make_template_request):
     """session.rollback() is called when DB commit fails."""
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
 
     rollback_mock = MagicMock()
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=Exception("DB failure")))
-    monkeypatch.setattr(in_memory_db, "rollback", rollback_mock)
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=Exception("DB failure")))
+    monkeypatch.setattr(rti_template_db, "rollback", rollback_mock)
 
     with pytest.raises(InternalServerException):
         await service.create_rti_template(template_request=make_template_request())
@@ -214,14 +213,14 @@ async def test_create_rti_template_rolls_back_session_on_failure(in_memory_db, m
 
 # update_rti_template tests
 @pytest.mark.asyncio
-async def test_update_rti_template_success(in_memory_db, make_file_service, make_template_request):
+async def test_update_rti_template_success(rti_template_db, make_file_service, make_template_request):
     """Happy path: template title and description are updated."""
-    # 1. pick an existing template ID from the in_memory_db fixture
-    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    # 1. pick an existing template ID from the rti_template_db fixture
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
     template_id = str(existing_template.id)
 
     fs = make_file_service()
-    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
 
     # 2. create a request with new title/desc but NO file
     request = make_template_request(id=template_id, title="Updated Title", description="Updated Desc")
@@ -235,14 +234,14 @@ async def test_update_rti_template_success(in_memory_db, make_file_service, make
     fs.update_file.assert_not_called()
 
 @pytest.mark.asyncio
-async def test_update_rti_template_with_file(in_memory_db, make_file_service, make_template_request):
+async def test_update_rti_template_with_file(rti_template_db, make_file_service, make_template_request):
     """Updating a template with a new file calls the file service's update_file."""
-    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
     template_id = str(existing_template.id)
     new_relative_path = "rti-templates/new-path.md"
 
     fs = make_file_service(relative_path=new_relative_path)
-    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
 
     request = make_template_request(id=template_id, title="New Title With File")
     
@@ -253,43 +252,43 @@ async def test_update_rti_template_with_file(in_memory_db, make_file_service, ma
     fs.update_file.assert_called_once()
     
 @pytest.mark.asyncio
-async def test_update_rti_template_not_found(in_memory_db, make_file_service, make_template_request):
+async def test_update_rti_template_not_found(rti_template_db, make_file_service, make_template_request):
     """NotFoundException is raised if the template ID doesn't exist in DB."""
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
     request = make_template_request(id=str(uuid.uuid4()))
 
     with pytest.raises(NotFoundException):
         await service.update_rti_template(template_request=request)
 
 @pytest.mark.asyncio
-async def test_update_rti_template_invalid_uuid(in_memory_db, make_file_service, make_template_request):
+async def test_update_rti_template_invalid_uuid(rti_template_db, make_file_service, make_template_request):
     """BadRequestException is raised if the ID is not a valid UUID string."""
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
     request = make_template_request(id="invalid-uuid")
 
     with pytest.raises(BadRequestException):
         await service.update_rti_template(template_request=request)
 
 @pytest.mark.asyncio
-async def test_update_rti_template_raises_when_file_service_fails(in_memory_db, make_file_service, make_template_request):
+async def test_update_rti_template_raises_when_file_service_fails(rti_template_db, make_file_service, make_template_request):
     """InternalServerException propagates when file service update fails."""
-    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
     fs = make_file_service(update_side_effect=InternalServerException("File update failed"))
-    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
     request = make_template_request(id=str(existing_template.id))
 
     with pytest.raises(InternalServerException):
         await service.update_rti_template(template_request=request)
 
 @pytest.mark.asyncio
-async def test_update_rti_template_rolls_back_on_db_failure(in_memory_db, monkeypatch, make_file_service, make_template_request):
+async def test_update_rti_template_rolls_back_on_db_failure(rti_template_db, monkeypatch, make_file_service, make_template_request):
     """session.rollback() is called if the DB commit fails during update."""
-    existing_template = in_memory_db.exec(select(RTITemplate)).first()
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
     
     rollback_mock = MagicMock()
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=Exception("DB fail during update")))
-    monkeypatch.setattr(in_memory_db, "rollback", rollback_mock)
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=Exception("DB fail during update")))
+    monkeypatch.setattr(rti_template_db, "rollback", rollback_mock)
 
     request = make_template_request(id=str(existing_template.id), title="Should Rollback")
     
@@ -300,9 +299,9 @@ async def test_update_rti_template_rolls_back_on_db_failure(in_memory_db, monkey
 
 
 @pytest.mark.asyncio
-async def test_update_rti_template_rolls_back_file_on_db_failure(in_memory_db, monkeypatch, make_file_service, make_template_request):
-    """restore_file is called as a compensating transaction when DB commit fails during update."""
-    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+async def test_update_rti_template_rolls_back_file_on_db_failure(rti_template_db, monkeypatch, make_file_service, make_template_request):
+    """update_file is called as a compensating transaction when DB commit fails during update."""
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
     template_id = str(existing_template.id)
     
     # Mock file data for restoration
@@ -317,108 +316,117 @@ async def test_update_rti_template_rolls_back_file_on_db_failure(in_memory_db, m
         {"content": b"# New Content", "sha": new_sha} # second call (new)
     ])
     
-    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
     
     # Mock DB failure
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=Exception("DB failure")))
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=Exception("DB failure")))
     
     request = make_template_request(id=template_id, title="Fail Me")
     
     with pytest.raises(InternalServerException):
         await service.update_rti_template(template_request=request)
     
-    # Verify restore_file was called with the OLD content and the NEW sha
-    fs.restore_file.assert_called_once_with(
-        template_id=existing_template.id,
+    # Verify update_file was called with the OLD content and the NEW sha to restore it
+    fs.update_file.assert_called_with(
+        file_path=f"rti-templates/{existing_template.id}.md",
         content=old_content,
-        sha=new_sha
+        sha=new_sha,
+        message=f"Rollback: restore previous version of rti-templates/{existing_template.id}.md"
     )
 
 # delete_rti_template tests
 @pytest.mark.asyncio
-async def test_delete_rti_template_success(in_memory_db, make_file_service):
+async def test_delete_rti_template_success(rti_template_db, make_file_service):
     """Happy path: template and its file are deleted."""
-    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
     template_id = existing_template.id
     file_path = existing_template.file
 
     fs = make_file_service()
-    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
 
     await service.delete_rti_template(template_id=str(template_id))
 
     # Verify DB deletion
-    db_record = in_memory_db.exec(select(RTITemplate).where(RTITemplate.id == template_id)).first()
+    db_record = rti_template_db.exec(select(RTITemplate).where(RTITemplate.id == template_id)).first()
     assert db_record is None
     # Verify File deletion
     fs.delete_file.assert_called_once_with(file_path=file_path)
 
 @pytest.mark.asyncio
-async def test_delete_rti_template_not_found(in_memory_db, make_file_service):
+async def test_delete_rti_template_not_found(rti_template_db, make_file_service):
     """NotFoundException is raised if the template ID doesn't exist."""
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
     random_id = str(uuid.uuid4())
 
     with pytest.raises(NotFoundException):
         await service.delete_rti_template(template_id=random_id)
 
 @pytest.mark.asyncio
-async def test_delete_rti_template_invalid_uuid(in_memory_db, make_file_service):
+async def test_delete_rti_template_invalid_uuid(rti_template_db, make_file_service):
     """BadRequestException is raised for malformed UUID strings."""
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
 
     with pytest.raises(BadRequestException):
         await service.delete_rti_template(template_id="not-a-uuid")
 
 @pytest.mark.asyncio
-async def test_delete_rti_template_integrity_error(in_memory_db, make_file_service, monkeypatch):
+async def test_delete_rti_template_integrity_error(rti_template_db, make_file_service, monkeypatch):
     """IntegrityError triggers rollback and recreates the file on GitHub."""
-    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
     template_id = existing_template.id
     
     fs = make_file_service()
     fs.get_file = AsyncMock(return_value={"content": b"Content", "sha": "sha"})
-    fs.recreate_file = AsyncMock(return_value=True)
+    fs.create_file = AsyncMock(return_value=True)
     
-    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
     
     # Mock commit to raise IntegrityError
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=IntegrityError("Conflict", None, None)))
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=IntegrityError("Conflict", None, None)))
     
     with pytest.raises(ConflictException):
         await service.delete_rti_template(template_id=str(template_id))
     
     # Verify compensating transaction
-    fs.recreate_file.assert_called_once_with(template_id=template_id, content=b"Content")
+    fs.create_file.assert_called_once_with(
+        file_path=existing_template.file, 
+        content=b"Content",
+        message=f"Recreate file {existing_template.file}"
+    )
 
 @pytest.mark.asyncio
-async def test_delete_rti_template_generic_exception(in_memory_db, make_file_service, monkeypatch):
+async def test_delete_rti_template_generic_exception(rti_template_db, make_file_service, monkeypatch):
     """Generic exception triggers rollback and recreates the file."""
-    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
     template_id = existing_template.id
     
     fs = make_file_service()
     fs.get_file = AsyncMock(return_value={"content": b"Content", "sha": "sha"})
-    fs.recreate_file = AsyncMock(return_value=True)
+    fs.create_file = AsyncMock(return_value=True)
     
-    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
     
     # Mock delete to raise Exception
-    monkeypatch.setattr(in_memory_db, "delete", MagicMock(side_effect=Exception("Unexpected error")))
+    monkeypatch.setattr(rti_template_db, "delete", MagicMock(side_effect=Exception("Unexpected error")))
     
     with pytest.raises(InternalServerException):
         await service.delete_rti_template(template_id=str(template_id))
     
-    fs.recreate_file.assert_called_once_with(template_id=template_id, content=b"Content")
+    fs.create_file.assert_called_once_with(
+        file_path=existing_template.file, 
+        content=b"Content",
+        message=f"Recreate file {existing_template.file}"
+    )
 
 # get_rti_template_by_id tests
 @pytest.mark.asyncio
-async def test_get_rti_template_by_id_success(in_memory_db, make_file_service):
+async def test_get_rti_template_by_id_success(rti_template_db, make_file_service):
     """Happy path: template is retrieved by ID."""
-    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
     template_id = str(existing_template.id)
 
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
     result = service.get_rti_template_by_id(template_id=template_id)
 
     assert isinstance(result, RTITemplateResponse)
@@ -426,18 +434,18 @@ async def test_get_rti_template_by_id_success(in_memory_db, make_file_service):
     assert result.title == existing_template.title
 
 @pytest.mark.asyncio
-async def test_get_rti_template_by_id_invalid_uuid(in_memory_db, make_file_service):
+async def test_get_rti_template_by_id_invalid_uuid(rti_template_db, make_file_service):
     """BadRequestException is raised for invalid UUID strings."""
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
     
     with pytest.raises(BadRequestException) as exc:
         service.get_rti_template_by_id(template_id="not-a-uuid")
     assert "Invalid UUID format" in str(exc.value)
 
 @pytest.mark.asyncio
-async def test_get_rti_template_by_id_not_found(in_memory_db, make_file_service):
+async def test_get_rti_template_by_id_not_found(rti_template_db, make_file_service):
     """NotFoundException is raised if the ID doesn't exist."""
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
     random_id = str(uuid.uuid4())
 
     with pytest.raises(NotFoundException) as exc:
@@ -445,15 +453,15 @@ async def test_get_rti_template_by_id_not_found(in_memory_db, make_file_service)
     assert "not found" in str(exc.value)
 
 @pytest.mark.asyncio
-async def test_get_rti_template_by_id_internal_error(in_memory_db, make_file_service, monkeypatch):
+async def test_get_rti_template_by_id_internal_error(rti_template_db, make_file_service, monkeypatch):
     """InternalServerException is raised on generic failure."""
-    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
     template_id = str(existing_template.id)
 
-    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
     
     # Mock session.get to raise an exception
-    monkeypatch.setattr(in_memory_db, "get", MagicMock(side_effect=Exception("DB breakdown")))
+    monkeypatch.setattr(rti_template_db, "get", MagicMock(side_effect=Exception("DB breakdown")))
     
     with pytest.raises(InternalServerException) as exc:
         service.get_rti_template_by_id(template_id=template_id)

--- a/tool/backend/test/test_rti_template_service.py
+++ b/tool/backend/test/test_rti_template_service.py
@@ -410,4 +410,52 @@ async def test_delete_rti_template_generic_exception(in_memory_db, make_file_ser
         await service.delete_rti_template(template_id=str(template_id))
     
     fs.recreate_file.assert_called_once_with(template_id=template_id, content=b"Content")
+
+# get_rti_template_by_id tests
+@pytest.mark.asyncio
+async def test_get_rti_template_by_id_success(in_memory_db, make_file_service):
+    """Happy path: template is retrieved by ID."""
+    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    template_id = str(existing_template.id)
+
+    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    result = service.get_rti_template_by_id(template_id=template_id)
+
+    assert isinstance(result, RTITemplateResponse)
+    assert result.id == existing_template.id
+    assert result.title == existing_template.title
+
+@pytest.mark.asyncio
+async def test_get_rti_template_by_id_invalid_uuid(in_memory_db, make_file_service):
+    """BadRequestException is raised for invalid UUID strings."""
+    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    
+    with pytest.raises(BadRequestException) as exc:
+        service.get_rti_template_by_id(template_id="not-a-uuid")
+    assert "Invalid UUID format" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_get_rti_template_by_id_not_found(in_memory_db, make_file_service):
+    """NotFoundException is raised if the ID doesn't exist."""
+    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    random_id = str(uuid.uuid4())
+
+    with pytest.raises(NotFoundException) as exc:
+        service.get_rti_template_by_id(template_id=random_id)
+    assert "not found" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_get_rti_template_by_id_internal_error(in_memory_db, make_file_service, monkeypatch):
+    """InternalServerException is raised on generic failure."""
+    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    template_id = str(existing_template.id)
+
+    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    
+    # Mock session.get to raise an exception
+    monkeypatch.setattr(in_memory_db, "get", MagicMock(side_effect=Exception("DB breakdown")))
+    
+    with pytest.raises(InternalServerException) as exc:
+        service.get_rti_template_by_id(template_id=template_id)
+    assert "Failed to read RTI template" in str(exc.value)
     

--- a/tool/backend/test/test_rti_template_service.py
+++ b/tool/backend/test/test_rti_template_service.py
@@ -210,6 +210,19 @@ async def test_create_rti_template_rolls_back_session_on_failure(rti_template_db
 
     rollback_mock.assert_called_once()
     
+@pytest.mark.asyncio
+async def test_create_rti_template_duplicate_title(rti_template_db, monkeypatch, make_file_service, make_template_request):
+    """IntegrityError (duplicate title) during create raises ConflictException."""
+    fs = make_file_service()
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
+    
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=IntegrityError("Conflict", None, None)))
+    
+    with pytest.raises(ConflictException) as exc:
+        await service.create_rti_template(template_request=make_template_request(title="Duplicate Title"))
+    
+    assert "already exists" in str(exc.value)
+    fs.delete_file.assert_called_once()
 
 # update_rti_template tests
 @pytest.mark.asyncio
@@ -325,6 +338,42 @@ async def test_update_rti_template_rolls_back_file_on_db_failure(rti_template_db
     
     with pytest.raises(InternalServerException):
         await service.update_rti_template(template_request=request)
+    
+    # Verify update_file was called with the OLD content and the NEW sha to restore it
+    fs.update_file.assert_called_with(
+        file_path=f"rti-templates/{existing_template.id}.md",
+        content=old_content,
+        sha=new_sha,
+        message=f"Rollback: restore previous version of rti-templates/{existing_template.id}.md"
+    )
+
+@pytest.mark.asyncio
+async def test_update_rti_template_duplicate_title(rti_template_db, monkeypatch, make_file_service, make_template_request):
+    """IntegrityError (duplicate title) during update triggers rollback, restores file, and raises ConflictException."""
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
+    template_id = str(existing_template.id)
+    
+    old_content = b"# Old Content"
+    old_sha = "old-sha"
+    new_sha = "new-sha"
+    
+    fs = make_file_service()
+    fs.get_file = AsyncMock(side_effect=[
+        {"content": old_content, "sha": old_sha}, # first call (old)
+        {"content": b"# New Content", "sha": new_sha} # second call (new)
+    ])
+    
+    service = RTITemplateService(session=rti_template_db, file_service=fs)
+    
+    # Mock commit to raise IntegrityError
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=IntegrityError("Conflict", None, None)))
+    
+    request = make_template_request(id=template_id, title="Duplicate Title")
+    
+    with pytest.raises(ConflictException) as exc:
+        await service.update_rti_template(template_request=request)
+    
+    assert "already exists" in str(exc.value)
     
     # Verify update_file was called with the OLD content and the NEW sha to restore it
     fs.update_file.assert_called_with(

--- a/tool/backend/test/test_rti_template_service.py
+++ b/tool/backend/test/test_rti_template_service.py
@@ -211,18 +211,33 @@ async def test_create_rti_template_rolls_back_session_on_failure(rti_template_db
     rollback_mock.assert_called_once()
     
 @pytest.mark.asyncio
-async def test_create_rti_template_duplicate_title(rti_template_db, monkeypatch, make_file_service, make_template_request):
-    """IntegrityError (duplicate title) during create raises ConflictException."""
+async def test_create_rti_template_duplicate_title(rti_template_db, make_file_service, make_template_request):
+    """Real DB unique-constraint collision on create raises ConflictException."""
+    # Get an existing template's title
+    existing_template = rti_template_db.exec(select(RTITemplate)).first()
+    duplicate_title = existing_template.title
+
     fs = make_file_service()
     service = RTITemplateService(session=rti_template_db, file_service=fs)
     
-    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=IntegrityError("Conflict", None, None)))
-    
     with pytest.raises(ConflictException) as exc:
-        await service.create_rti_template(template_request=make_template_request(title="Duplicate Title"))
+        await service.create_rti_template(template_request=make_template_request(title=duplicate_title))
     
     assert "already exists" in str(exc.value)
     fs.delete_file.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_create_rti_template_no_extension(rti_template_db, make_file_service, make_template_request):
+    """BadRequestException is raised if the uploaded file has no extension."""
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
+    
+    request = make_template_request()
+    request.file.filename = "no_extension_file"
+    
+    with pytest.raises(BadRequestException) as exc:
+        await service.create_rti_template(template_request=request)
+    
+    assert "doesn't have any file extension" in str(exc.value)
 
 # update_rti_template tests
 @pytest.mark.asyncio
@@ -323,8 +338,8 @@ async def test_update_rti_template_rolls_back_file_on_db_failure(rti_template_db
     new_sha = "new-sha"
     
     fs = make_file_service()
-    # Mock get_file to return different SHAs on successive calls
-    fs.get_file = AsyncMock(side_effect=[
+    # Mock read_file to return different SHAs on successive calls
+    fs.read_file = AsyncMock(side_effect=[
         {"content": old_content, "sha": old_sha}, # first call (old)
         {"content": b"# New Content", "sha": new_sha} # second call (new)
     ])
@@ -341,46 +356,44 @@ async def test_update_rti_template_rolls_back_file_on_db_failure(rti_template_db
     
     # Verify update_file was called with the OLD content and the NEW sha to restore it
     fs.update_file.assert_called_with(
-        file_path=f"rti-templates/{existing_template.id}.md",
+        file_path=existing_template.file,
         content=old_content,
         sha=new_sha,
-        message=f"Rollback: restore previous version of rti-templates/{existing_template.id}.md"
+        message=f"Rollback: restore previous version of {existing_template.file}"
     )
 
 @pytest.mark.asyncio
-async def test_update_rti_template_duplicate_title(rti_template_db, monkeypatch, make_file_service, make_template_request):
-    """IntegrityError (duplicate title) during update triggers rollback, restores file, and raises ConflictException."""
-    existing_template = rti_template_db.exec(select(RTITemplate)).first()
-    template_id = str(existing_template.id)
-    
+async def test_update_rti_template_duplicate_title(rti_template_db, make_file_service, make_template_request):
+    """Real DB unique-constraint collision on update raises ConflictException."""
+    templates = rti_template_db.exec(select(RTITemplate)).all()
+    target_template = templates[0]          # The template we will try to update
+    duplicate_title = templates[1].title    # A title that already belongs to another template
+
     old_content = b"# Old Content"
     old_sha = "old-sha"
     new_sha = "new-sha"
     
     fs = make_file_service()
-    fs.get_file = AsyncMock(side_effect=[
+    fs.read_file = AsyncMock(side_effect=[
         {"content": old_content, "sha": old_sha}, # first call (old)
         {"content": b"# New Content", "sha": new_sha} # second call (new)
     ])
     
     service = RTITemplateService(session=rti_template_db, file_service=fs)
-    
-    # Mock commit to raise IntegrityError
-    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=IntegrityError("Conflict", None, None)))
-    
-    request = make_template_request(id=template_id, title="Duplicate Title")
+
+    request = make_template_request(id=str(target_template.id), title=duplicate_title)
     
     with pytest.raises(ConflictException) as exc:
         await service.update_rti_template(template_request=request)
     
     assert "already exists" in str(exc.value)
     
-    # Verify update_file was called with the OLD content and the NEW sha to restore it
+    # Verify compensating transaction (rollback)
     fs.update_file.assert_called_with(
-        file_path=f"rti-templates/{existing_template.id}.md",
+        file_path=target_template.file,
         content=old_content,
         sha=new_sha,
-        message=f"Rollback: restore previous version of rti-templates/{existing_template.id}.md"
+        message=f"Rollback: restore previous version of {target_template.file}"
     )
 
 # delete_rti_template tests
@@ -426,7 +439,7 @@ async def test_delete_rti_template_integrity_error(rti_template_db, make_file_se
     template_id = existing_template.id
     
     fs = make_file_service()
-    fs.get_file = AsyncMock(return_value={"content": b"Content", "sha": "sha"})
+    fs.read_file = AsyncMock(return_value={"content": b"Content", "sha": "sha"})
     fs.create_file = AsyncMock(return_value=True)
     
     service = RTITemplateService(session=rti_template_db, file_service=fs)
@@ -451,7 +464,7 @@ async def test_delete_rti_template_generic_exception(rti_template_db, make_file_
     template_id = existing_template.id
     
     fs = make_file_service()
-    fs.get_file = AsyncMock(return_value={"content": b"Content", "sha": "sha"})
+    fs.read_file = AsyncMock(return_value={"content": b"Content", "sha": "sha"})
     fs.create_file = AsyncMock(return_value=True)
     
     service = RTITemplateService(session=rti_template_db, file_service=fs)

--- a/tool/backend/test/test_rti_template_service.py
+++ b/tool/backend/test/test_rti_template_service.py
@@ -2,11 +2,11 @@
 import uuid
 import pytest
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock, patch
 from sqlalchemy.exc import OperationalError
 from src.services.rti_template_service import RTITemplateService
 from src.models.response_models import RTITemplateResponse
-from src.core.exceptions import InternalServerException
+from src.core.exceptions import InternalServerException, BadRequestException, NotFoundException
 from sqlmodel import SQLModel, Session, create_engine, select
 from src.models import RTITemplate
 
@@ -210,4 +210,127 @@ async def test_create_rti_template_rolls_back_session_on_failure(in_memory_db, m
         await service.create_rti_template(template_request=make_template_request())
 
     rollback_mock.assert_called_once()
+    
+
+# update_rti_template tests
+@pytest.mark.asyncio
+async def test_update_rti_template_success(in_memory_db, make_file_service, make_template_request):
+    """Happy path: template title and description are updated."""
+    # 1. pick an existing template ID from the in_memory_db fixture
+    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    template_id = str(existing_template.id)
+
+    fs = make_file_service()
+    service = RTITemplateService(session=in_memory_db, file_service=fs)
+
+    # 2. create a request with new title/desc but NO file
+    request = make_template_request(id=template_id, title="Updated Title", description="Updated Desc")
+    request.file = None
+
+    result = await service.update_rti_template(template_request=request)
+
+    assert result.id == existing_template.id
+    assert result.title == "Updated Title"
+    assert result.description == "Updated Desc"
+    fs.update_file.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_update_rti_template_with_file(in_memory_db, make_file_service, make_template_request):
+    """Updating a template with a new file calls the file service's update_file."""
+    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    template_id = str(existing_template.id)
+    new_relative_path = "rti-templates/new-path.md"
+
+    fs = make_file_service(relative_path=new_relative_path)
+    service = RTITemplateService(session=in_memory_db, file_service=fs)
+
+    request = make_template_request(id=template_id, title="New Title With File")
+    
+    result = await service.update_rti_template(template_request=request)
+
+    assert result.title == "New Title With File"
+    assert result.file == new_relative_path
+    fs.update_file.assert_called_once()
+    
+@pytest.mark.asyncio
+async def test_update_rti_template_not_found(in_memory_db, make_file_service, make_template_request):
+    """NotFoundException is raised if the template ID doesn't exist in DB."""
+    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    request = make_template_request(id=str(uuid.uuid4()))
+
+    with pytest.raises(NotFoundException):
+        await service.update_rti_template(template_request=request)
+
+@pytest.mark.asyncio
+async def test_update_rti_template_invalid_uuid(in_memory_db, make_file_service, make_template_request):
+    """BadRequestException is raised if the ID is not a valid UUID string."""
+    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    request = make_template_request(id="invalid-uuid")
+
+    with pytest.raises(BadRequestException):
+        await service.update_rti_template(template_request=request)
+
+@pytest.mark.asyncio
+async def test_update_rti_template_raises_when_file_service_fails(in_memory_db, make_file_service, make_template_request):
+    """InternalServerException propagates when file service update fails."""
+    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    fs = make_file_service(update_side_effect=InternalServerException("File update failed"))
+    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    request = make_template_request(id=str(existing_template.id))
+
+    with pytest.raises(InternalServerException):
+        await service.update_rti_template(template_request=request)
+
+@pytest.mark.asyncio
+async def test_update_rti_template_rolls_back_on_db_failure(in_memory_db, monkeypatch, make_file_service, make_template_request):
+    """session.rollback() is called if the DB commit fails during update."""
+    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    
+    rollback_mock = MagicMock()
+    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=Exception("DB fail during update")))
+    monkeypatch.setattr(in_memory_db, "rollback", rollback_mock)
+
+    request = make_template_request(id=str(existing_template.id), title="Should Rollback")
+    
+    with pytest.raises(InternalServerException):
+        await service.update_rti_template(template_request=request)
+
+    rollback_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_rti_template_rolls_back_file_on_db_failure(in_memory_db, monkeypatch, make_file_service, make_template_request):
+    """restore_file is called as a compensating transaction when DB commit fails during update."""
+    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    template_id = str(existing_template.id)
+    
+    # Mock file data for restoration
+    old_content = b"# Old Content"
+    old_sha = "old-sha"
+    new_sha = "new-sha"
+    
+    fs = make_file_service()
+    # Mock get_file to return different SHAs on successive calls
+    fs.get_file = AsyncMock(side_effect=[
+        {"content": old_content, "sha": old_sha}, # first call (old)
+        {"content": b"# New Content", "sha": new_sha} # second call (new)
+    ])
+    
+    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    
+    # Mock DB failure
+    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=Exception("DB failure")))
+    
+    request = make_template_request(id=template_id, title="Fail Me")
+    
+    with pytest.raises(InternalServerException):
+        await service.update_rti_template(template_request=request)
+    
+    # Verify restore_file was called with the OLD content and the NEW sha
+    fs.restore_file.assert_called_once_with(
+        template_id=existing_template.id,
+        content=old_content,
+        sha=new_sha
+    )
     

--- a/tool/backend/test/test_rti_template_service.py
+++ b/tool/backend/test/test_rti_template_service.py
@@ -3,10 +3,10 @@ import uuid
 import pytest
 from datetime import datetime
 from unittest.mock import MagicMock, AsyncMock, patch
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, IntegrityError
 from src.services.rti_template_service import RTITemplateService
 from src.models.response_models import RTITemplateResponse
-from src.core.exceptions import InternalServerException, BadRequestException, NotFoundException
+from src.core.exceptions import InternalServerException, BadRequestException, NotFoundException, ConflictException
 from sqlmodel import SQLModel, Session, create_engine, select
 from src.models import RTITemplate
 
@@ -333,4 +333,81 @@ async def test_update_rti_template_rolls_back_file_on_db_failure(in_memory_db, m
         content=old_content,
         sha=new_sha
     )
+
+# delete_rti_template tests
+@pytest.mark.asyncio
+async def test_delete_rti_template_success(in_memory_db, make_file_service):
+    """Happy path: template and its file are deleted."""
+    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    template_id = existing_template.id
+    file_path = existing_template.file
+
+    fs = make_file_service()
+    service = RTITemplateService(session=in_memory_db, file_service=fs)
+
+    await service.delete_rti_template(template_id=str(template_id))
+
+    # Verify DB deletion
+    db_record = in_memory_db.exec(select(RTITemplate).where(RTITemplate.id == template_id)).first()
+    assert db_record is None
+    # Verify File deletion
+    fs.delete_file.assert_called_once_with(file_path=file_path)
+
+@pytest.mark.asyncio
+async def test_delete_rti_template_not_found(in_memory_db, make_file_service):
+    """NotFoundException is raised if the template ID doesn't exist."""
+    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+    random_id = str(uuid.uuid4())
+
+    with pytest.raises(NotFoundException):
+        await service.delete_rti_template(template_id=random_id)
+
+@pytest.mark.asyncio
+async def test_delete_rti_template_invalid_uuid(in_memory_db, make_file_service):
+    """BadRequestException is raised for malformed UUID strings."""
+    service = RTITemplateService(session=in_memory_db, file_service=make_file_service())
+
+    with pytest.raises(BadRequestException):
+        await service.delete_rti_template(template_id="not-a-uuid")
+
+@pytest.mark.asyncio
+async def test_delete_rti_template_integrity_error(in_memory_db, make_file_service, monkeypatch):
+    """IntegrityError triggers rollback and recreates the file on GitHub."""
+    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    template_id = existing_template.id
+    
+    fs = make_file_service()
+    fs.get_file = AsyncMock(return_value={"content": b"Content", "sha": "sha"})
+    fs.recreate_file = AsyncMock(return_value=True)
+    
+    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    
+    # Mock commit to raise IntegrityError
+    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=IntegrityError("Conflict", None, None)))
+    
+    with pytest.raises(ConflictException):
+        await service.delete_rti_template(template_id=str(template_id))
+    
+    # Verify compensating transaction
+    fs.recreate_file.assert_called_once_with(template_id=template_id, content=b"Content")
+
+@pytest.mark.asyncio
+async def test_delete_rti_template_generic_exception(in_memory_db, make_file_service, monkeypatch):
+    """Generic exception triggers rollback and recreates the file."""
+    existing_template = in_memory_db.exec(select(RTITemplate)).first()
+    template_id = existing_template.id
+    
+    fs = make_file_service()
+    fs.get_file = AsyncMock(return_value={"content": b"Content", "sha": "sha"})
+    fs.recreate_file = AsyncMock(return_value=True)
+    
+    service = RTITemplateService(session=in_memory_db, file_service=fs)
+    
+    # Mock delete to raise Exception
+    monkeypatch.setattr(in_memory_db, "delete", MagicMock(side_effect=Exception("Unexpected error")))
+    
+    with pytest.raises(InternalServerException):
+        await service.delete_rti_template(template_id=str(template_id))
+    
+    fs.recreate_file.assert_called_once_with(template_id=template_id, content=b"Content")
     

--- a/tool/backend/test/test_sender_service.py
+++ b/tool/backend/test/test_sender_service.py
@@ -80,8 +80,8 @@ def test_send_good_request():
 
 # Unit tests – SenderService.create_sender
 
-def test_create_sender_with_email_returns_response(in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
+def test_create_sender_with_email_returns_response(rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
     result = service.create_sender(sender_request=make_sender_request())
 
     assert isinstance(result, SenderResponse)
@@ -89,8 +89,8 @@ def test_create_sender_with_email_returns_response(in_memory_db, make_sender_req
     assert result.email == "john@example.com"
     assert isinstance(result.id, uuid.UUID)
 
-def test_create_sender_with_contact_no_returns_response(in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
+def test_create_sender_with_contact_no_returns_response(rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
     result = service.create_sender(
         sender_request=make_sender_request(email=None, contact_no="0771234567")
     )
@@ -98,8 +98,8 @@ def test_create_sender_with_contact_no_returns_response(in_memory_db, make_sende
     assert result.contact_no == "0771234567"
     assert result.email is None
 
-def test_create_sender_with_all_fields(in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
+def test_create_sender_with_all_fields(rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
     result = service.create_sender(
         sender_request=make_sender_request(
             email="john@example.com",
@@ -113,34 +113,34 @@ def test_create_sender_with_all_fields(in_memory_db, make_sender_request):
     assert result.email == "john@example.com"
     assert result.contact_no == "0771234567"
 
-def test_create_sender_persists_to_db(in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
+def test_create_sender_persists_to_db(rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
     result = service.create_sender(sender_request=make_sender_request())
 
-    db_record = in_memory_db.exec(select(Sender).where(Sender.id == result.id)).first()
+    db_record = rti_template_db.exec(select(Sender).where(Sender.id == result.id)).first()
     assert db_record is not None
     assert db_record.name == "John Doe"
     assert db_record.email == "john@example.com"
 
-def test_create_sender_response_has_timestamps(in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
+def test_create_sender_response_has_timestamps(rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
     result = service.create_sender(sender_request=make_sender_request())
 
     assert isinstance(result.created_at, datetime)
     assert isinstance(result.updated_at, datetime)
 
-def test_create_sender_raises_internal_on_db_error(monkeypatch, in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=Exception("DB failure")))
+def test_create_sender_raises_internal_on_db_error(monkeypatch, rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=Exception("DB failure")))
 
     with pytest.raises(InternalServerException):
         service.create_sender(sender_request=make_sender_request())
 
-def test_create_sender_rolls_back_on_db_error(monkeypatch, in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
+def test_create_sender_rolls_back_on_db_error(monkeypatch, rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
     rollback_mock = MagicMock()
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=Exception("DB failure")))
-    monkeypatch.setattr(in_memory_db, "rollback", rollback_mock)
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=Exception("DB failure")))
+    monkeypatch.setattr(rti_template_db, "rollback", rollback_mock)
 
     with pytest.raises(InternalServerException):
         service.create_sender(sender_request=make_sender_request())
@@ -157,38 +157,38 @@ def _make_integrity_error(constraint_name: str):
     orig.diag = diag
     return IntegrityError(statement=None, params=None, orig=orig)
 
-def test_create_sender_raises_conflict_on_duplicate_email(monkeypatch, in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=_make_integrity_error("senders_email_key")))
+def test_create_sender_raises_conflict_on_duplicate_email(monkeypatch, rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=_make_integrity_error("senders_email_key")))
 
     with pytest.raises(ConflictException) as exc_info:
         service.create_sender(sender_request=make_sender_request())
     assert "Email" in exc_info.value.message
 
-def test_create_sender_raises_conflict_on_duplicate_contact_no(monkeypatch, in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=_make_integrity_error("senders_contact_no_key")))
+def test_create_sender_raises_conflict_on_duplicate_contact_no(monkeypatch, rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=_make_integrity_error("senders_contact_no_key")))
 
     with pytest.raises(ConflictException) as exc_info:
         service.create_sender(sender_request=make_sender_request(email=None, contact_no="0771234567"))
     assert "Contact" in exc_info.value.message
 
-def test_create_sender_rolls_back_on_integrity_error(monkeypatch, in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
+def test_create_sender_rolls_back_on_integrity_error(monkeypatch, rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
     rollback_mock = MagicMock()
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=_make_integrity_error("senders_email_key")))
-    monkeypatch.setattr(in_memory_db, "rollback", rollback_mock)
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=_make_integrity_error("senders_email_key")))
+    monkeypatch.setattr(rti_template_db, "rollback", rollback_mock)
 
     with pytest.raises(ConflictException):
         service.create_sender(sender_request=make_sender_request())
     rollback_mock.assert_called_once()
 
-def test_create_sender_integrity_error_default_fallback(monkeypatch, in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
+def test_create_sender_integrity_error_default_fallback(monkeypatch, rti_template_db, make_sender_request):
+    service = SenderService(session=rti_template_db)
 
     rollback_mock = MagicMock()
-    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=_make_integrity_error("unknown_constraint")))
-    monkeypatch.setattr(in_memory_db, "rollback", rollback_mock)
+    monkeypatch.setattr(rti_template_db, "commit", MagicMock(side_effect=_make_integrity_error("unknown_constraint")))
+    monkeypatch.setattr(rti_template_db, "rollback", rollback_mock)
 
     with pytest.raises(ConflictException) as exc:
         service.create_sender(sender_request=make_sender_request())


### PR DESCRIPTION
## Overview
This PR introduces three new API endpoints that enables **RTI Template** update, deletion and read by ID. The implementation allows clients to update an existing RTI Template, Delete and Get the data for RTI Template by given ID.

**New API endpoint:**
`PUT /rti-request/{id}`
`GET /rti-request/{id}`
`DELETE /rti-request/{id}`

---

## Changes
* **Routing:** Added new routers to the `rti_template_router.py` file.
* **Service Layer:** Developed the services in the `rti_template_service.py` file.
* **Integration:** Updated the GitHub REST file service with the required functions.
* **Testing:** Added new test cases to cover the service functionalities.

---

## Testing
* **Service Tests:** Updated `test_rti_template_service.py` with new test cases to cover the new endpoint.
* **File Service Tests:** Created `test_file_service.py` to cover tests for the `FileService`.
* **Mocks:** Updated `conftest.py` with new mock services.
* **Status:** All tests are passing.

---

## Additional Information
This PR Closes #37, Closes #38, Closes #64