### PR TITLE
GH-40: [RTI][TOOL][BACKEND] Institution List Retrieval API

### DIFF
--- a/tool/backend/main.py
+++ b/tool/backend/main.py
@@ -1,6 +1,6 @@
 import logging
 from src.utils.http_client import http_client
-from src.routers import rti_template_router
+from src.routers import rti_template_router, institution_router
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
@@ -45,6 +45,8 @@ def health_check():
     return {"status": "Healthy Service"}
 
 app.include_router(rti_template_router)
+app.include_router(institution_router)
+
 app.add_exception_handler(BaseAPIException, api_exception_handler)
 
 

--- a/tool/backend/src/models/__init__.py
+++ b/tool/backend/src/models/__init__.py
@@ -1,9 +1,10 @@
-from .table_schemas import RTITemplate
+from .table_schemas import RTITemplate, Institutions
 from .common import User, PaginationModel, UserRole
 
 __all__ = [
     "RTITemplate",
     "PaginationModel",
     "User",
-    "UserRole"
+    "UserRole",
+    "Institutions"
 ]

--- a/tool/backend/src/models/__init__.py
+++ b/tool/backend/src/models/__init__.py
@@ -1,4 +1,4 @@
-from .table_schemas import RTITemplate, Institutions
+from .table_schemas import RTITemplate, Institution
 from .common import User, PaginationModel, UserRole
 
 __all__ = [
@@ -6,5 +6,5 @@ __all__ = [
     "PaginationModel",
     "User",
     "UserRole",
-    "Institutions"
+    "Institution"
 ]

--- a/tool/backend/src/models/response_models/__init__.py
+++ b/tool/backend/src/models/response_models/__init__.py
@@ -1,8 +1,11 @@
 from .rti_templates import RTITemplateResponse, RTITemplateListResponse, RTITemplateRequest
+from .institutions import InstitutionListResponse, InstitutionResponse
 
 __all__ = [
     "RTITemplateResponse",
     "RTITemplateListResponse",
-    "RTITemplateRequest"
+    "RTITemplateRequest",
+    "InstitutionListResponse",
+    "InstitutionResponse"
 ]
 

--- a/tool/backend/src/models/response_models/institutions.py
+++ b/tool/backend/src/models/response_models/institutions.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from uuid import UUID
+from src.models import PaginationModel
+from typing import Sequence
+from pydantic import BaseModel, ConfigDict, Field
+    
+class InstitutionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    # attributes
+    id: UUID = Field(..., description="Unique identifier for the institution")
+    name: str = Field(..., description="Name of the institution")
+    created_at: datetime = Field(..., description="ISO 8601 timestamp of when the template was created")
+    updated_at: datetime = Field(..., description="ISO 8601 timestamp of when the template was last updated")
+
+class InstitutionListResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    # attributes
+    data: Sequence[InstitutionResponse] = Field([], description="List of institutions")
+    pagination: PaginationModel = Field(..., description="Pagination metadata")
+

--- a/tool/backend/src/models/response_models/institutions.py
+++ b/tool/backend/src/models/response_models/institutions.py
@@ -9,8 +9,8 @@ class InstitutionResponse(BaseModel):
     # attributes
     id: UUID = Field(..., description="Unique identifier for the institution")
     name: str = Field(..., description="Name of the institution")
-    created_at: datetime = Field(..., description="ISO 8601 timestamp of when the template was created")
-    updated_at: datetime = Field(..., description="ISO 8601 timestamp of when the template was last updated")
+    created_at: datetime = Field(..., description="ISO 8601 timestamp of when the institution was created")
+    updated_at: datetime = Field(..., description="ISO 8601 timestamp of when the institution was last updated")
 
 class InstitutionListResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)

--- a/tool/backend/src/models/table_schemas/__init__.py
+++ b/tool/backend/src/models/table_schemas/__init__.py
@@ -1,5 +1,6 @@
-from .table_schemas import RTITemplate
+from .table_schemas import RTITemplate, Institutions
 
 __all__ = [
-    "RTITemplate"
+    "RTITemplate",
+    "Institutions"
 ]

--- a/tool/backend/src/models/table_schemas/__init__.py
+++ b/tool/backend/src/models/table_schemas/__init__.py
@@ -1,6 +1,6 @@
-from .table_schemas import RTITemplate, Institutions
+from .table_schemas import RTITemplate, Institution
 
 __all__ = [
     "RTITemplate",
-    "Institutions"
+    "Institution"
 ]

--- a/tool/backend/src/models/table_schemas/table_schemas.py
+++ b/tool/backend/src/models/table_schemas/table_schemas.py
@@ -13,3 +13,13 @@ class RTITemplate(SQLModel, table=True):
     file: str = Field(..., description="URL of the RTI template markdown file")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the template was created")
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the template was last updated")
+
+class Institutions(SQLModel, table=True):
+    __tablename__ = "institutions"
+
+    # table fields
+    id: UUID = Field(primary_key=True, description="Unique identifier for the institution")
+    name: str = Field(index=True, unique=True, description="Title of the institution")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the institution was created")
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the institution was last updated")
+    

--- a/tool/backend/src/models/table_schemas/table_schemas.py
+++ b/tool/backend/src/models/table_schemas/table_schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, func
 
 class RTITemplate(SQLModel, table=True):
     __tablename__ = "rti_templates"
@@ -14,12 +14,16 @@ class RTITemplate(SQLModel, table=True):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the template was created")
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the template was last updated")
 
-class Institutions(SQLModel, table=True):
+class Institution(SQLModel, table=True):
     __tablename__ = "institutions"
 
     # table fields
     id: UUID = Field(primary_key=True, description="Unique identifier for the institution")
-    name: str = Field(index=True, unique=True, description="Title of the institution")
+    name: str = Field(index=True, unique=True, description="Name of the institution")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the institution was created")
-    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the institution was last updated")
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column_kwargs={"onupdate": func.now()},
+        description="ISO 8601 timestamp of when the institution was last updated"
+    )
     

--- a/tool/backend/src/models/table_schemas/table_schemas.py
+++ b/tool/backend/src/models/table_schemas/table_schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
-from sqlmodel import SQLModel, Field, func
+from sqlmodel import SQLModel, Field
 
 class RTITemplate(SQLModel, table=True):
     __tablename__ = "rti_templates"
@@ -23,7 +23,7 @@ class Institution(SQLModel, table=True):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the institution was created")
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
-        sa_column_kwargs={"onupdate": func.now()},
+        sa_column_kwargs={"onupdate": lambda: datetime.now(timezone.utc)},
         description="ISO 8601 timestamp of when the institution was last updated"
     )
     

--- a/tool/backend/src/routers/__init__.py
+++ b/tool/backend/src/routers/__init__.py
@@ -1,6 +1,7 @@
 from .rti_template_router import router as rti_template_router
-
+from .institution_router import router as institution_router
 
 __all__ = [
-    "rti_template_router"
+    "rti_template_router",
+    "institution_router"
 ]

--- a/tool/backend/src/routers/institution_router.py
+++ b/tool/backend/src/routers/institution_router.py
@@ -1,0 +1,22 @@
+from src.services.institution_service import InstitutionService
+from src.repositories.db import SessionDep
+from src.models.response_models import InstitutionListResponse
+from src.dependencies import RoleChecker
+from src.models import UserRole, User
+from fastapi import Depends, Query
+from fastapi.routing import APIRouter
+
+router = APIRouter(prefix="/api/v1", tags=["Institutions"])
+
+def get_institution_service(session: SessionDep):
+    return InstitutionService(session)
+
+@router.get("/institutions", response_model=InstitutionListResponse)
+def get_institutions_endpoint(
+    page: int = Query(1, ge=1, description="page number"),
+    page_size: int = Query(10, ge=1, le=100, description="page size"),
+    service: InstitutionService = Depends(get_institution_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    ):
+    response = service.get_institutions(page=page, page_size=page_size)
+    return response

--- a/tool/backend/src/services/institution_service.py
+++ b/tool/backend/src/services/institution_service.py
@@ -1,7 +1,7 @@
 import logging
 from src.models import PaginationModel
 from src.models.response_models import InstitutionListResponse, InstitutionResponse
-from src.models.table_schemas import Institutions
+from src.models.table_schemas import Institution
 from src.core.exceptions import InternalServerException
 from sqlmodel import Session, select, func
 
@@ -26,11 +26,11 @@ class InstitutionService:
             offset = (page - 1) * page_size
 
             # fetch the records from the table
-            statement_records = select(Institutions).offset(offset).limit(page_size)
+            statement_records = select(Institution).offset(offset).limit(page_size)
             results = self.session.exec(statement_records).all()
             
             # fetch the total record count
-            statement_count = select(func.count()).select_from(Institutions)
+            statement_count = select(func.count()).select_from(Institution)
             total_items = self.session.exec(statement_count).one()
 
             # pagination response

--- a/tool/backend/src/services/institution_service.py
+++ b/tool/backend/src/services/institution_service.py
@@ -1,0 +1,51 @@
+import logging
+from src.models import PaginationModel
+from src.models.response_models import InstitutionListResponse, InstitutionResponse
+from src.models.table_schemas import Institutions
+from src.core.exceptions import InternalServerException
+from sqlmodel import Session, select, func
+
+logger = logging.getLogger(__name__)
+
+class InstitutionService:
+    """
+    This service is responsible for executing all institution operations.
+    """
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    # API
+    def get_institutions(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 10
+    ) -> InstitutionListResponse:
+        try:
+            offset = (page - 1) * page_size
+
+            # fetch the records from the table
+            statement_records = select(Institutions).offset(offset).limit(page_size)
+            results = self.session.exec(statement_records).all()
+            
+            # fetch the total record count
+            statement_count = select(func.count()).select_from(Institutions)
+            total_items = self.session.exec(statement_count).one()
+
+            # pagination response
+            pagination = PaginationModel(
+                page=page,
+                pageSize=page_size,
+                totalItem=total_items,
+                totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
+            )
+            
+            # return the final response
+            return InstitutionListResponse(
+                data=[InstitutionResponse.model_validate(r) for r in results],
+                pagination=pagination
+            )
+        except Exception as e:
+            logger.error(f"Error fetching Institutions: {e}")
+            raise InternalServerException("Failed to fetch Institutions from database.") from e

--- a/tool/backend/src/services/institution_service.py
+++ b/tool/backend/src/services/institution_service.py
@@ -26,7 +26,7 @@ class InstitutionService:
             offset = (page - 1) * page_size
 
             # fetch the records from the table
-            statement_records = select(Institution).offset(offset).limit(page_size)
+            statement_records = select(Institution).order_by(Institution.created_at.desc()).offset(offset).limit(page_size)
             results = self.session.exec(statement_records).all()
             
             # fetch the total record count

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -4,7 +4,7 @@ import uuid
 from aiohttp import ClientError
 from datetime import datetime, timezone
 from sqlmodel import SQLModel, Session, create_engine
-from src.models import RTITemplate
+from src.models import RTITemplate, Institution
 from src.models.response_models import RTITemplateRequest
 from src.services.github_file_service import GithubFileService
 from fastapi import UploadFile
@@ -149,4 +149,38 @@ def make_template_request():
         request.file = mock_upload
         return request
     return _factory
+
+@pytest.fixture
+def institution_db():
+    """Create an in-memory SQLite DB and provide a fresh session with test institutions."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    now = datetime.now(timezone.utc)
     
+    institutions = [
+        Institution(
+            id=uuid.uuid4(),
+            name="Institution 1",
+            created_at=now,
+            updated_at=now,
+        ),
+        Institution(
+            id=uuid.uuid4(),
+            name="Institution 2",
+            created_at=now,
+            updated_at=now,
+        ),
+        Institution(
+            id=uuid.uuid4(),
+            name="Institution 3",
+            created_at=now,
+            updated_at=now,
+        ),
+    ]
+    
+    with Session(engine) as session:
+        session.add_all(institutions)
+        session.commit()
+        # We need to refresh objects if we want to use them after commit, 
+        # but for tests we often just want the session.
+        yield session

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -2,7 +2,7 @@
 import pytest
 import uuid
 from aiohttp import ClientError
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from sqlmodel import SQLModel, Session, create_engine
 from src.models import RTITemplate, Institution
 from src.models.response_models import RTITemplateRequest
@@ -161,14 +161,14 @@ def institution_db():
         Institution(
             id=uuid.uuid4(),
             name="Institution 1",
-            created_at=now,
-            updated_at=now,
+            created_at=now - timedelta(hours=2),
+            updated_at=now - timedelta(hours=2),
         ),
         Institution(
             id=uuid.uuid4(),
             name="Institution 2",
-            created_at=now,
-            updated_at=now,
+            created_at=now - timedelta(hours=1),
+            updated_at=now - timedelta(hours=1),
         ),
         Institution(
             id=uuid.uuid4(),

--- a/tool/backend/test/test_institution_service.py
+++ b/tool/backend/test/test_institution_service.py
@@ -1,0 +1,58 @@
+# tests/test_institution_service.py
+import pytest
+from sqlalchemy.exc import OperationalError
+from src.services.institution_service import InstitutionService
+from src.models.response_models import InstitutionListResponse
+from src.core.exceptions import InternalServerException
+from sqlmodel import SQLModel, Session, create_engine
+
+def test_get_institutions_default(institution_db):
+    """Test fetching institutions with default pagination (page 1, size 10)."""
+    service = InstitutionService(session=institution_db)
+    response = service.get_institutions()
+    
+    assert isinstance(response, InstitutionListResponse)
+    assert response.pagination.page == 1
+    assert response.pagination.pageSize == 10
+    assert response.pagination.totalItem == 3
+    assert response.pagination.totalPages == 1
+    assert len(response.data) == 3
+
+def test_get_institutions_custom_pagination(institution_db):
+    """Test fetching institutions with custom page and page size."""
+    service = InstitutionService(session=institution_db)
+    response = service.get_institutions(page=2, page_size=2)
+    
+    assert response.pagination.page == 2
+    assert response.pagination.pageSize == 2
+    assert response.pagination.totalItem == 3
+    assert response.pagination.totalPages == 2
+    assert len(response.data) == 1  # Only 1 record left for page 2
+
+def test_get_institutions_empty_db():
+    """Test behavior when no institutions exist in the database."""
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        service = InstitutionService(session=session)
+        response = service.get_institutions()
+        
+        assert response.pagination.totalItem == 0
+        assert response.pagination.totalPages == 0
+        assert response.data == []
+
+def test_get_institutions_db_error(monkeypatch, institution_db):
+    """Test that InternalServerException is raised when a database error occurs."""
+    service = InstitutionService(session=institution_db)
+    
+    # Mock the session to raise an error during execution
+    def mock_exec(*args, **kwargs):
+        raise OperationalError("Fake DB error", None, None)
+    
+    monkeypatch.setattr(institution_db, "exec", mock_exec)
+    
+    with pytest.raises(InternalServerException) as excinfo:
+        service.get_institutions()
+    
+    assert "Failed to fetch Institutions from database" in str(excinfo.value)
+

--- a/tool/backend/test/test_institution_service.py
+++ b/tool/backend/test/test_institution_service.py
@@ -17,6 +17,11 @@ def test_get_institutions_default(institution_db):
     assert response.pagination.totalItem == 3
     assert response.pagination.totalPages == 1
     assert len(response.data) == 3
+    # verify sorting order (descending by created_at)
+    # Institution 3 (now) should be first, Institution 1 (now - 2h) should be last
+    assert response.data[0].name == "Institution 3"
+    assert response.data[1].name == "Institution 2"
+    assert response.data[2].name == "Institution 1"
 
 def test_get_institutions_custom_pagination(institution_db):
     """Test fetching institutions with custom page and page size."""


### PR DESCRIPTION
## Overview
This PR introduces a new API endpoint that enables **Institutions** list retrieval. The implementation allows clients to retrive the institutions based on the given page number and page limit. (defaults to 1st page with 10 items)

**New API endpoint:**
`GET /institutions`

---

## Changes
* **Routing:** Added a new router to the `institution_router.py` file and inject in the `main.py`.
* **Service Layer:** Developed the service in the `institution_service.py` file.
* **Testing:** Added new test cases.

---

## Testing
* **Service Tests:** Updated `test_institution_service.py` with new test cases to cover the new endpoint.
* **Mocks:** Updated `conftest.py` with new mock services.
* **Status:** All tests are passing.

---

## Additional Information
This PR Closes #40 