### PR TITLE
GH-56: [RTI][TOOL][BACKEND] Position List Retrieval API 

### DIFF
--- a/tool/backend/main.py
+++ b/tool/backend/main.py
@@ -1,6 +1,6 @@
 import logging
 from src.utils.http_client import http_client
-from src.routers import rti_template_router, institution_router
+from src.routers import rti_template_router, institution_router, position_router
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
@@ -46,7 +46,6 @@ def health_check():
 
 app.include_router(rti_template_router)
 app.include_router(institution_router)
-
+app.include_router(position_router)
 app.add_exception_handler(BaseAPIException, api_exception_handler)
-
 

--- a/tool/backend/src/models/__init__.py
+++ b/tool/backend/src/models/__init__.py
@@ -1,8 +1,9 @@
-from .table_schemas import RTITemplate, Institution
+from .table_schemas import RTITemplate, Institution, Position
 from .common import User, PaginationModel, UserRole
 
 __all__ = [
     "RTITemplate",
+    "Position",
     "PaginationModel",
     "User",
     "UserRole",

--- a/tool/backend/src/models/response_models/__init__.py
+++ b/tool/backend/src/models/response_models/__init__.py
@@ -1,5 +1,6 @@
 from .rti_templates import RTITemplateResponse, RTITemplateListResponse, RTITemplateRequest
 from .institutions import InstitutionListResponse, InstitutionResponse
+from .positions import PositionListResponse, PositionResponse
 
 __all__ = [
     "RTITemplateResponse",
@@ -7,5 +8,7 @@ __all__ = [
     "RTITemplateRequest",
     "InstitutionListResponse",
     "InstitutionResponse"
+    "PositionListResponse",
+    "PositionResponse"
 ]
 

--- a/tool/backend/src/models/response_models/positions.py
+++ b/tool/backend/src/models/response_models/positions.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from uuid import UUID
+from src.models import PaginationModel
+from typing import Sequence
+from pydantic import BaseModel, ConfigDict, Field
+    
+class PositionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    # attributes
+    id: UUID = Field(..., description="Unique identifier for the position")
+    name: str = Field(..., description="Name of the position")
+    created_at: datetime = Field(..., description="ISO 8601 timestamp of when the position was created")
+    updated_at: datetime = Field(..., description="ISO 8601 timestamp of when the position was last updated")
+
+class PositionListResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    # attributes
+    data: Sequence[PositionResponse] = Field([], description="List of positions")
+    pagination: PaginationModel = Field(..., description="Pagination metadata")

--- a/tool/backend/src/models/table_schemas/__init__.py
+++ b/tool/backend/src/models/table_schemas/__init__.py
@@ -1,6 +1,7 @@
-from .table_schemas import RTITemplate, Institution
+from .table_schemas import RTITemplate, Institution, Position
 
 __all__ = [
     "RTITemplate",
-    "Institution"
+    "Institution",
+    "Position"
 ]

--- a/tool/backend/src/models/table_schemas/table_schemas.py
+++ b/tool/backend/src/models/table_schemas/table_schemas.py
@@ -36,6 +36,6 @@ class Position(SQLModel, table=True):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the position was created")
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
-        sa_column_kwargs={"onupdate": func.now()},
+        sa_column_kwargs={"onupdate": lambda: datetime.now(timezone.utc)},
         description="ISO 8601 timestamp of when the position was last updated"
     )

--- a/tool/backend/src/models/table_schemas/table_schemas.py
+++ b/tool/backend/src/models/table_schemas/table_schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, func
 
 class RTITemplate(SQLModel, table=True):
     __tablename__ = "rti_templates"
@@ -27,3 +27,15 @@ class Institution(SQLModel, table=True):
         description="ISO 8601 timestamp of when the institution was last updated"
     )
     
+class Position(SQLModel, table=True):
+    __tablename__ = "positions"
+
+    # table fields
+    id: UUID = Field(primary_key=True, description="Unique identifier for the position")
+    name: str = Field(index=True, unique=True, description="Name of the position")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the position was created")
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column_kwargs={"onupdate": func.now()},
+        description="ISO 8601 timestamp of when the position was last updated"
+    )

--- a/tool/backend/src/routers/__init__.py
+++ b/tool/backend/src/routers/__init__.py
@@ -1,7 +1,10 @@
 from .rti_template_router import router as rti_template_router
 from .institution_router import router as institution_router
+from .position_router import router as position_router
+
 
 __all__ = [
     "rti_template_router",
-    "institution_router"
+    "institution_router",
+    "position_router"
 ]

--- a/tool/backend/src/routers/position_router.py
+++ b/tool/backend/src/routers/position_router.py
@@ -1,0 +1,22 @@
+from src.services import PositionService
+from src.repositories.db import SessionDep
+from src.models.response_models import PositionListResponse
+from src.dependencies import RoleChecker
+from src.models import UserRole, User
+from fastapi import Depends, Query
+from fastapi.routing import APIRouter
+
+router = APIRouter(prefix="/api/v1", tags=["Positions"])
+
+def get_position_service(session: SessionDep):
+    return PositionService(session)
+
+@router.get("/positions", response_model=PositionListResponse)
+def get_positions_endpoint(
+    page: int = Query(1, ge=1, description="page number"),
+    page_size: int = Query(10, ge=1, le=100, description="page size"),
+    service: PositionService = Depends(get_position_service),
+    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    ):
+    response = service.get_positions(page=page, page_size=page_size)
+    return response

--- a/tool/backend/src/routers/position_router.py
+++ b/tool/backend/src/routers/position_router.py
@@ -16,7 +16,7 @@ def get_positions_endpoint(
     page: int = Query(1, ge=1, description="page number"),
     page_size: int = Query(10, ge=1, le=100, description="page size"),
     service: PositionService = Depends(get_position_service),
-    # user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
     ):
     response = service.get_positions(page=page, page_size=page_size)
     return response

--- a/tool/backend/src/services/__init__.py
+++ b/tool/backend/src/services/__init__.py
@@ -1,9 +1,11 @@
 from .rti_template_service import RTITemplateService
+from .position_service import PositionService
 from .auth_service import AuthService
 from .github_file_service import GithubFileService
 
 __all__ = [
     "RTITemplateService",
     "AuthService",
-    "GithubFileService"
+    "GithubFileService",
+    "PositionService"
 ]

--- a/tool/backend/src/services/position_service.py
+++ b/tool/backend/src/services/position_service.py
@@ -1,0 +1,51 @@
+import logging
+from src.models import PaginationModel
+from src.models.response_models import PositionListResponse, PositionResponse
+from src.models.table_schemas import Position
+from src.core.exceptions import InternalServerException
+from sqlmodel import Session, select, func
+
+logger = logging.getLogger(__name__)
+
+class PositionService:
+    """
+    This service is responsible for executing all position operations.
+    """
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    # API
+    def get_positions(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 10
+    ) -> PositionListResponse:
+        try:
+            offset = (page - 1) * page_size
+
+            # fetch the records from the table
+            statement_records = select(Position).order_by(Position.created_at.desc()).offset(offset).limit(page_size)
+            results = self.session.exec(statement_records).all()
+            
+            # fetch the total record count
+            statement_count = select(func.count()).select_from(Position)
+            total_items = self.session.exec(statement_count).one()
+
+            # pagination response
+            pagination = PaginationModel(
+                page=page,
+                pageSize=page_size,
+                totalItem=total_items,
+                totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
+            )
+            
+            # return the final response
+            return PositionListResponse(
+                data=[PositionResponse.model_validate(r) for r in results],
+                pagination=pagination
+            )
+        except Exception as e:
+            logger.error(f"Error fetching positions: {e}")
+            raise InternalServerException("Failed to fetch positions from database.") from e

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -4,7 +4,7 @@ import uuid
 from aiohttp import ClientError
 from datetime import datetime, timezone, timedelta
 from sqlmodel import SQLModel, Session, create_engine
-from src.models import RTITemplate, Institution
+from src.models import RTITemplate, Institution, Position
 from src.models.response_models import RTITemplateRequest
 from src.services.github_file_service import GithubFileService
 from fastapi import UploadFile
@@ -184,3 +184,40 @@ def institution_db():
         # We need to refresh objects if we want to use them after commit, 
         # but for tests we often just want the session.
         yield session
+
+@pytest.fixture
+def position_db():
+    """Create an in-memory SQLite DB and provide a fresh session with test positions."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    now = datetime.now(timezone.utc)
+    
+    positions = [
+        Position(
+            id=uuid.uuid4(),
+            name="Position 1",
+            created_at=now - timedelta(hours=2),
+            updated_at=now - timedelta(hours=2),
+        ),
+        Position(
+            id=uuid.uuid4(),
+            name="Position 2",
+            created_at=now - timedelta(hours=1),
+            updated_at=now - timedelta(hours=1),
+        ),
+        Position(
+            id=uuid.uuid4(),
+            name="Position 3",
+            created_at=now,
+            updated_at=now,
+        ),
+    ]
+    
+    with Session(engine) as session:
+        session.add_all(positions)
+        session.commit()
+        # We need to refresh objects if we want to use them after commit, 
+        # but for tests we often just want the session.
+        yield session
+
+    

--- a/tool/backend/test/test_position_service.py
+++ b/tool/backend/test/test_position_service.py
@@ -1,0 +1,62 @@
+# tests/test_position_service.py
+import pytest
+from sqlalchemy.exc import OperationalError
+from src.services.position_service import PositionService
+from src.models.response_models import PositionListResponse
+from src.core.exceptions import InternalServerException
+from sqlmodel import SQLModel, Session, create_engine
+
+def test_get_positions_default(position_db):
+    """Test fetching positions with default pagination (page 1, size 10)."""
+    service = PositionService(session=position_db)
+    response = service.get_positions()
+    
+    assert isinstance(response, PositionListResponse)
+    assert response.pagination.page == 1
+    assert response.pagination.pageSize == 10
+    assert response.pagination.totalItem == 3
+    assert response.pagination.totalPages == 1
+    assert len(response.data) == 3
+    # verify sorting order (descending by created_at)
+    # Position 3 (now) should be first, Position 1 (now - 2h) should be last
+    assert response.data[0].name == "Position 3"
+    assert response.data[1].name == "Position 2"
+    assert response.data[2].name == "Position 1"
+
+def test_get_positions_custom_pagination(position_db):
+    """Test fetching positions with custom page and page size."""
+    service = PositionService(session=position_db)
+    response = service.get_positions(page=2, page_size=2)
+    
+    assert response.pagination.page == 2
+    assert response.pagination.pageSize == 2
+    assert response.pagination.totalItem == 3
+    assert response.pagination.totalPages == 2
+    assert len(response.data) == 1  # Only 1 record left for page 2
+
+def test_get_positions_empty_db():
+    """Test behavior when no positions exist in the database."""
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        service = PositionService(session=session)
+        response = service.get_positions()
+        
+        assert response.pagination.totalItem == 0
+        assert response.pagination.totalPages == 0
+        assert response.data == []
+
+def test_get_positions_db_error(monkeypatch, position_db):
+    """Test that InternalServerException is raised when a database error occurs."""
+    service = PositionService(session=position_db)
+    
+    # Mock the session to raise an error during execution
+    def mock_exec(*args, **kwargs):
+        raise OperationalError("Fake DB error", None, None)
+    
+    monkeypatch.setattr(position_db, "exec", mock_exec)
+    
+    with pytest.raises(InternalServerException) as excinfo:
+        service.get_positions()
+    
+    assert "Failed to fetch positions from database" in str(excinfo.value)


### PR DESCRIPTION
## Overview
This PR introduces a new API endpoint that enables **Positions** list retrieval. The implementation allows clients to retrieve the positions based on the given page number and page limit. (defaults to 1st page with 10 items)

**New API endpoint:**
`GET /positions`

---

## Changes
* **Routing:** Added a new router `position_router.py` file and inject in the `main.py`.
* **Service Layer:** Developed the service in the `position_service.py` file.
* **Testing:** Added new test cases.

---

## Testing
* **Service Tests:** Updated `test_position_service.py` with new test cases to cover the new endpoint.
* **Mocks:** Updated `conftest.py` with new mock services.
* **Status:** All tests are passing.

---

## Additional Information
This PR Closes #56 