### PR TITLE
GH-43: [RTI][TOOL][BACKEND] Sender creation endpoint 

### DIFF
--- a/tool/backend/contract/components/schemas/senders.yaml
+++ b/tool/backend/contract/components/schemas/senders.yaml
@@ -67,7 +67,7 @@ SenderRequest:
       type: string
       example: "0771234567"
       description: Contact number of the sender.
-  oneOf:
+  anyOf:
     - required: [email]
     - required: [contactNo]
 

--- a/tool/backend/contract/components/schemas/senders.yaml
+++ b/tool/backend/contract/components/schemas/senders.yaml
@@ -32,13 +32,13 @@ SenderResponse:
       type: string
       example: "0771234567"
       description: Contact number of the sender.
-    createdAt:
+    created_at:
       type: string
       format: date-time
       readOnly: true
       example: "2026-03-31T09:00:00Z"
       description: ISO 8601 timestamp of when the sender was created (UTC).
-    updatedAt:
+    updated_at:
       type: string
       format: date-time
       readOnly: true

--- a/tool/backend/contract/components/schemas/senders.yaml
+++ b/tool/backend/contract/components/schemas/senders.yaml
@@ -5,7 +5,7 @@ SenderResponse:
     - name
     - email
     - address
-    - contactNo
+    - contact_no
     - createdAt
     - updatedAt
   properties:
@@ -28,7 +28,7 @@ SenderResponse:
       type: string
       example: 123 Main St, Colombo 01
       description: Address of the sender.
-    contactNo:
+    contact_no:
       type: string
       example: "0771234567"
       description: Contact number of the sender.
@@ -63,13 +63,13 @@ SenderRequest:
       type: string
       example: 123 Main St, Colombo 01
       description: Address of the sender.
-    contactNo:
+    contact_no:
       type: string
       example: "0771234567"
       description: Contact number of the sender.
   anyOf:
     - required: [email]
-    - required: [contactNo]
+    - required: [contact_no]
 
 SenderListResponse:
   type: object

--- a/tool/backend/contract/paths/senders.yaml
+++ b/tool/backend/contract/paths/senders.yaml
@@ -1,5 +1,5 @@
 /senders:
-  # Create a new sender 
+  # Create a new sender
   post:
     summary: Create a sender
     operationId: createSender
@@ -27,7 +27,7 @@
               name: John Doe
               email: example@gmail.com
               address: 123 Main St, Colombo 01
-              contactNo: "0771234567"
+              contact_no: "0771234567"
               createdAt: "2026-03-31T09:00:00Z"
               updatedAt: "2026-03-31T09:00:00Z"
       "401":
@@ -62,7 +62,7 @@
                   name: John Doe
                   email: example@gmail.com
                   address: 123 Main St, Colombo 01
-                  contactNo: "0771234567"
+                  contact_no: "0771234567"
                   createdAt: "2026-03-31T09:00:00Z"
                   updatedAt: "2026-03-31T09:00:00Z"
               pagination:
@@ -99,7 +99,7 @@
               name: John Doe
               email: example@gmail.com
               address: 123 Main St, Colombo 01
-              contactNo: "0771234567"
+              contact_no: "0771234567"
               createdAt: "2026-03-31T09:00:00Z"
               updatedAt: "2026-03-31T09:00:00Z"
       "401":
@@ -139,7 +139,7 @@
               name: John Doe
               email: example@gmail.com
               address: 123 Main St, Colombo 01
-              contactNo: "0771234567"
+              contact_no: "0771234567"
               createdAt: "2026-03-31T09:00:00Z"
               updatedAt: "2026-03-31T09:00:00Z"
       "401":

--- a/tool/backend/main.py
+++ b/tool/backend/main.py
@@ -1,6 +1,6 @@
 import logging
 from src.utils.http_client import http_client
-from src.routers import rti_template_router, institution_router, position_router
+from src.routers import rti_template_router, institution_router, position_router, sender_router
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
@@ -47,5 +47,6 @@ def health_check():
 app.include_router(rti_template_router)
 app.include_router(institution_router)
 app.include_router(position_router)
+app.include_router(sender_router)
 app.add_exception_handler(BaseAPIException, api_exception_handler)
 

--- a/tool/backend/main.py
+++ b/tool/backend/main.py
@@ -4,8 +4,10 @@ from src.routers import rti_template_router, institution_router, position_router
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
-from src.core.exceptions import BaseAPIException, api_exception_handler
+from src.core.exceptions import BaseAPIException, api_exception_handler, validation_exception_handler
 from src.core.configs import settings
+from fastapi.exceptions import RequestValidationError
+
 
 # Configure logging to show INFO level messages
 logging.basicConfig(level=logging.INFO)
@@ -49,4 +51,5 @@ app.include_router(institution_router)
 app.include_router(position_router)
 app.include_router(sender_router)
 app.add_exception_handler(BaseAPIException, api_exception_handler)
+app.add_exception_handler(RequestValidationError, validation_exception_handler)
 

--- a/tool/backend/pyproject.toml
+++ b/tool/backend/pyproject.toml
@@ -17,4 +17,5 @@ dependencies = [
     "requests>=2.33.1",
     "sqlmodel>=0.0.38",
     "uvicorn>=0.42.0",
+    "email-validator>=2.0.0"
 ]

--- a/tool/backend/src/core/__init__.py
+++ b/tool/backend/src/core/__init__.py
@@ -1,5 +1,25 @@
 from .configs import settings
+from .exceptions import (
+    BaseAPIException,
+    BadRequestException,
+    ConflictException,
+    UnauthorizedException,
+    ForbiddenException,
+    NotFoundException,
+    UnprocessableEntityException,
+    InternalServerException,
+    api_exception_handler
+)
 
 __all__ = [
-    "settings"
+    "settings",
+    "BaseAPIException",
+    "BadRequestException",
+    "ConflictException",
+    "UnauthorizedException",
+    "ForbiddenException",
+    "NotFoundException",
+    "UnprocessableEntityException",
+    "InternalServerException",
+    "api_exception_handler"
 ]

--- a/tool/backend/src/core/__init__.py
+++ b/tool/backend/src/core/__init__.py
@@ -8,7 +8,8 @@ from .exceptions import (
     NotFoundException,
     UnprocessableEntityException,
     InternalServerException,
-    api_exception_handler
+    api_exception_handler,
+    validation_exception_handler
 )
 
 __all__ = [
@@ -21,5 +22,6 @@ __all__ = [
     "NotFoundException",
     "UnprocessableEntityException",
     "InternalServerException",
-    "api_exception_handler"
+    "api_exception_handler",
+    "validation_exception_handler"
 ]

--- a/tool/backend/src/core/exceptions.py
+++ b/tool/backend/src/core/exceptions.py
@@ -1,6 +1,18 @@
 from fastapi import Request, status
 from fastapi.responses import JSONResponse
-from src.models.common import ErrorResponse
+from pydantic import BaseModel, ConfigDict, Field
+from datetime import datetime, timezone
+
+class ErrorResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    # attributes
+    status: int = Field(..., description="HTTP status code")
+    error: str = Field(..., description="Short error category")
+    message: str = Field(..., description="Human-readable error detail")
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="ISO 8601 timestamp of when the error occurred (UTC)"
+    )
 
 class BaseAPIException(Exception):
     """Base exception for all API errors."""
@@ -51,13 +63,6 @@ class NotFoundException(BaseAPIException):
     error_code = "Not Found"
     
     def __init__(self, message: str = "The requested resource was not found."):
-        super().__init__(message)
-
-class ConflictException(BaseAPIException):
-    status_code = status.HTTP_409_CONFLICT
-    error_code = "Resource Conflict"
-    
-    def __init__(self, message: str = "A resource conflict occurred."):
         super().__init__(message)
 
 class UnprocessableEntityException(BaseAPIException):

--- a/tool/backend/src/core/exceptions.py
+++ b/tool/backend/src/core/exceptions.py
@@ -2,6 +2,8 @@ from fastapi import Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
+from typing import Any
+from fastapi.exceptions import RequestValidationError
 
 class ErrorResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
@@ -9,6 +11,10 @@ class ErrorResponse(BaseModel):
     status: int = Field(..., description="HTTP status code")
     error: str = Field(..., description="Short error category")
     message: str = Field(..., description="Human-readable error detail")
+    details: list[dict[str, Any]] | None = Field(       
+        default=None,
+        description="Optional list of field-level validation errors"
+    )
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         description="ISO 8601 timestamp of when the error occurred (UTC)"
@@ -66,7 +72,7 @@ class NotFoundException(BaseAPIException):
         super().__init__(message)
 
 class UnprocessableEntityException(BaseAPIException):
-    status_code = status.HTTP_422_UNPROCESSABLE_CONTENT
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
     error_code = "Unprocessable Entity"
     
     def __init__(self, message: str = "Validation failed."):
@@ -84,5 +90,42 @@ async def api_exception_handler(request: Request, exc: BaseAPIException):
     return JSONResponse(
         status_code=exc.status_code,
         content=exc.to_response().model_dump(mode="json")
+    )
+
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+
+    details = []
+
+    for err in exc.errors():
+        loc = err.get("loc", [])
+        field = ".".join(str(x) for x in loc if x != "body")
+
+        error_type = err.get("type")
+        message = err.get("msg")
+
+        if error_type == "string_type":
+            message = "Must be a string"
+        elif error_type == "int_type":
+            message = "Must be a number"
+        elif error_type == "value_error.email":
+            message = "Must be a valid email address"
+        elif error_type == "missing":
+            message = "This field is required"
+
+        details.append({
+            "field": field,
+            "message": message
+        })
+
+    response = ErrorResponse(       
+        status=422,
+        error="Validation Error",
+        message="Invalid request payload",
+        details=details,
+    )
+
+    return JSONResponse(
+        status_code=422,
+        content=response.model_dump(mode="json")
     )
     

--- a/tool/backend/src/core/exceptions.py
+++ b/tool/backend/src/core/exceptions.py
@@ -99,33 +99,22 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     for err in exc.errors():
         loc = err.get("loc", [])
         field = ".".join(str(x) for x in loc if x != "body")
-
-        error_type = err.get("type")
-        message = err.get("msg")
-
-        if error_type == "string_type":
-            message = "Must be a string"
-        elif error_type == "int_type":
-            message = "Must be a number"
-        elif error_type == "value_error.email":
-            message = "Must be a valid email address"
-        elif error_type == "missing":
-            message = "This field is required"
+        message = err.get("msg", "Invalid request payload")
 
         details.append({
-            "field": field,
+            "field": field or "invalid_input_field",
             "message": message
         })
 
     response = ErrorResponse(       
-        status=422,
+        status=status.HTTP_422_UNPROCESSABLE_CONTENT,
         error="Validation Error",
         message="Invalid request payload",
         details=details,
     )
 
     return JSONResponse(
-        status_code=422,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         content=response.model_dump(mode="json")
     )
     

--- a/tool/backend/src/core/exceptions.py
+++ b/tool/backend/src/core/exceptions.py
@@ -72,7 +72,7 @@ class NotFoundException(BaseAPIException):
         super().__init__(message)
 
 class UnprocessableEntityException(BaseAPIException):
-    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    status_code = status.HTTP_422_UNPROCESSABLE_CONTENT
     error_code = "Unprocessable Entity"
     
     def __init__(self, message: str = "Validation failed."):

--- a/tool/backend/src/core/exceptions.py
+++ b/tool/backend/src/core/exceptions.py
@@ -25,6 +25,13 @@ class BadRequestException(BaseAPIException):
     def __init__(self, message: str = "Bad request"):
         super().__init__(message)
 
+class ConflictException(BaseAPIException):
+    status_code = status.HTTP_409_CONFLICT
+    error_code = "Resource Conflict"
+    
+    def __init__(self, message: str = "A resource conflict occurred."):
+        super().__init__(message)
+
 class UnauthorizedException(BaseAPIException):
     status_code = status.HTTP_401_UNAUTHORIZED
     error_code = "Unauthorized"

--- a/tool/backend/src/models/__init__.py
+++ b/tool/backend/src/models/__init__.py
@@ -1,5 +1,7 @@
-from .table_schemas import RTITemplate, Institution, Position
+from .table_schemas import RTITemplate, Sender, Institution, Position
 from .common import User, PaginationModel, UserRole
+from .request_models import SenderRequest
+from .response_models import SenderResponse
 
 __all__ = [
     "RTITemplate",
@@ -7,5 +9,8 @@ __all__ = [
     "PaginationModel",
     "User",
     "UserRole",
-    "Institution"
+    "Institution",
+    "SenderRequest",
+    "SenderResponse",
+    "Sender"
 ]

--- a/tool/backend/src/models/__init__.py
+++ b/tool/backend/src/models/__init__.py
@@ -1,7 +1,7 @@
 from .table_schemas import RTITemplate, Sender, Institution, Position
 from .common import User, PaginationModel, UserRole
 from .request_models import SenderRequest
-from .response_models import SenderResponse
+from .response_models import SenderResponse , SenderListResponse
 
 __all__ = [
     "RTITemplate",
@@ -12,5 +12,6 @@ __all__ = [
     "Institution",
     "SenderRequest",
     "SenderResponse",
-    "Sender"
+    "Sender",
+    "SenderListResponse"
 ]

--- a/tool/backend/src/models/common/__init__.py
+++ b/tool/backend/src/models/common/__init__.py
@@ -1,9 +1,8 @@
-from .common import PaginationModel, ErrorResponse
+from .common import PaginationModel
 from .auth import User, UserRole
 
 __all__ = [
     "PaginationModel",
-    "ErrorResponse",
     "User",
     "UserRole"
 ]

--- a/tool/backend/src/models/common/common.py
+++ b/tool/backend/src/models/common/common.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel, ConfigDict, Field
-from datetime import datetime, timezone
 
 class PaginationModel(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
@@ -8,14 +7,3 @@ class PaginationModel(BaseModel):
     pageSize: int = Field(10, ge=1, le=100, description="Number of items per page")
     totalItem: int = Field(0, ge=0, description="Total number of items available")
     totalPages: int = Field(0, ge=0, description="Total number of pages based on pageSize")
-
-class ErrorResponse(BaseModel):
-    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
-    # attributes
-    status: int = Field(..., description="HTTP status code")
-    error: str = Field(..., description="Short error category")
-    message: str = Field(..., description="Human-readable error detail")
-    timestamp: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc),
-        description="ISO 8601 timestamp of when the error occurred (UTC)"
-    )

--- a/tool/backend/src/models/request_models/__init__.py
+++ b/tool/backend/src/models/request_models/__init__.py
@@ -1,0 +1,5 @@
+from .senders import SenderRequest
+
+__all__ = [
+    "SenderRequest"
+]

--- a/tool/backend/src/models/request_models/senders.py
+++ b/tool/backend/src/models/request_models/senders.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, Field, ConfigDict, EmailStr, model_validator
+from typing import Optional
+
+class SenderRequest(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    # attributes
+    name: str = Field(..., example="John Doe", description="Name of the sender.")
+    email: Optional[EmailStr] = Field(
+        None, example="example@gmail.com", description="Email of the sender."
+    )
+    address: Optional[str] = Field(
+        None, example="123 Main St, Colombo 01", description="Address of the sender."
+    )
+    contactNo: Optional[str] = Field(
+        None, example="0771234567", description="Contact number of the sender."
+    )
+    # either email or contactNo must be provided
+    @model_validator(mode="after")
+    def validate_email_or_contact(self):
+        if not self.email and not self.contactNo:
+            raise ValueError("Either email or contactNo must be provided.")
+        return self

--- a/tool/backend/src/models/request_models/senders.py
+++ b/tool/backend/src/models/request_models/senders.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field, ConfigDict, EmailStr, model_validator
 from typing import Optional
 
+
 class SenderRequest(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
     # attributes
@@ -11,12 +12,13 @@ class SenderRequest(BaseModel):
     address: Optional[str] = Field(
         None, example="123 Main St, Colombo 01", description="Address of the sender."
     )
-    contactNo: Optional[str] = Field(
+    contact_no: Optional[str] = Field(
         None, example="0771234567", description="Contact number of the sender."
     )
-    # either email or contactNo must be provided
+
+    # either email or contact_no must be provided
     @model_validator(mode="after")
     def validate_email_or_contact(self):
-        if not self.email and not self.contactNo:
-            raise ValueError("Either email or contactNo must be provided.")
+        if not self.email and not self.contact_no:
+            raise ValueError("Either email or contact_no must be provided.")
         return self

--- a/tool/backend/src/models/request_models/senders.py
+++ b/tool/backend/src/models/request_models/senders.py
@@ -6,15 +6,15 @@ from src.core.exceptions import BadRequestException
 class SenderRequest(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
     # attributes
-    name: str = Field(..., example="John Doe", description="Name of the sender.")
+    name: str = Field(..., json_schema_extra={"example":"John Doe"}, description="Name of the sender.")
     email: Optional[EmailStr] = Field(
-        None, example="example@gmail.com", description="Email of the sender."
+        None, json_schema_extra={"example":"example@gmail.com"}, description="Email of the sender."
     )
     address: Optional[str] = Field(
-        None, example="123 Main St, Colombo 01", description="Address of the sender."
+        None, json_schema_extra={"example":"123 Main St, Colombo 01"}, description="Address of the sender."
     )
     contact_no: Optional[str] = Field(
-        None, example="0771234567", description="Contact number of the sender."
+        None, json_schema_extra={"example":"0771234567"}, description="Contact number of the sender."
     )
 
     # either email or contact_no must be provided

--- a/tool/backend/src/models/request_models/senders.py
+++ b/tool/backend/src/models/request_models/senders.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field, ConfigDict, EmailStr, model_validator
 from typing import Optional
+from src.core.exceptions import BadRequestException
 
 
 class SenderRequest(BaseModel):
@@ -20,5 +21,5 @@ class SenderRequest(BaseModel):
     @model_validator(mode="after")
     def validate_email_or_contact(self):
         if not self.email and not self.contact_no:
-            raise ValueError("Either email or contact_no must be provided.")
+            raise BadRequestException("Either email or contact_no must be provided.")
         return self

--- a/tool/backend/src/models/request_models/senders.py
+++ b/tool/backend/src/models/request_models/senders.py
@@ -14,7 +14,7 @@ class SenderRequest(BaseModel):
         None, json_schema_extra={"example":"123 Main St, Colombo 01"}, description="Address of the sender."
     )
     contact_no: Optional[str] = Field(
-        None, json_schema_extra={"example":"0771234567"}, description="Contact number of the sender."
+        None, pattern=r"^\+?\d{10,15}$", json_schema_extra={"example":"0771234567"}, description="Contact number of the sender."
     )
 
     # either email or contact_no must be provided

--- a/tool/backend/src/models/response_models/__init__.py
+++ b/tool/backend/src/models/response_models/__init__.py
@@ -1,11 +1,14 @@
 from .rti_templates import RTITemplateResponse, RTITemplateListResponse, RTITemplateRequest
 from .institutions import InstitutionListResponse, InstitutionResponse
 from .positions import PositionListResponse, PositionResponse
+from .senders import SenderResponse, SenderListResponse
 
 __all__ = [
     "RTITemplateResponse",
     "RTITemplateListResponse",
     "RTITemplateRequest",
+    "SenderResponse",
+    "SenderListResponse",
     "InstitutionListResponse",
     "InstitutionResponse"
     "PositionListResponse",

--- a/tool/backend/src/models/response_models/senders.py
+++ b/tool/backend/src/models/response_models/senders.py
@@ -1,8 +1,9 @@
 from pydantic import BaseModel, ConfigDict, Field
 from uuid import UUID
 from datetime import datetime
-from typing import Optional ,Sequence
+from typing import Optional, Sequence
 from src.models import PaginationModel
+
 
 class SenderResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
@@ -19,7 +20,7 @@ class SenderResponse(BaseModel):
     address: Optional[str] = Field(
         None, example="123 Main St, Colombo 01", description="Address of the sender"
     )
-    contactNo: Optional[str] = Field(
+    contact_no: Optional[str] = Field(
         None, example="0771234567", description="Contact number of the sender"
     )
     created_at: datetime = Field(
@@ -32,6 +33,7 @@ class SenderResponse(BaseModel):
         example="2026-03-31T09:00:00Z",
         description="ISO 8601 timestamp of when the sender was last updated",
     )
+
 
 class SenderListResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)

--- a/tool/backend/src/models/response_models/senders.py
+++ b/tool/backend/src/models/response_models/senders.py
@@ -10,27 +10,27 @@ class SenderResponse(BaseModel):
     # attributes
     id: UUID = Field(
         ...,
-        example="123e4567-e89b-12d3-a456-426614174000",
+        json_schema_extra={"example":"123e4567-e89b-12d3-a456-426614174000"},
         description="Unique identifier for the sender",
     )
-    name: str = Field(..., example="John Doe", description="Name of the sender")
+    name: str = Field(..., json_schema_extra={"example":"John Doe"}, description="Name of the sender")
     email: Optional[str] = Field(
-        None, example="example@gmail.com", description="Email of the sender"
+        None, json_schema_extra={"example":"example@gmail.com"}, description="Email of the sender"
     )
     address: Optional[str] = Field(
-        None, example="123 Main St, Colombo 01", description="Address of the sender"
+        None, json_schema_extra={"example":"123 Main St, Colombo 01"}, description="Address of the sender"
     )
     contact_no: Optional[str] = Field(
-        None, example="0771234567", description="Contact number of the sender"
+        None, json_schema_extra={"example":"0771234567"}, description="Contact number of the sender"
     )
     created_at: datetime = Field(
         ...,
-        example="2026-03-31T09:00:00Z",
+        json_schema_extra={"example":"2026-03-31T09:00:00Z"},
         description="ISO 8601 timestamp of when the sender was created",
     )
     updated_at: datetime = Field(
         ...,
-        example="2026-03-31T09:00:00Z",
+        json_schema_extra={"example":"2026-03-31T09:00:00Z"},
         description="ISO 8601 timestamp of when the sender was last updated",
     )
 

--- a/tool/backend/src/models/response_models/senders.py
+++ b/tool/backend/src/models/response_models/senders.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel, ConfigDict, Field
+from uuid import UUID
+from datetime import datetime
+from typing import Optional ,Sequence
+from src.models import PaginationModel
+
+class SenderResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    # attributes
+    id: UUID = Field(
+        ...,
+        example="123e4567-e89b-12d3-a456-426614174000",
+        description="Unique identifier for the sender",
+    )
+    name: str = Field(..., example="John Doe", description="Name of the sender")
+    email: Optional[str] = Field(
+        None, example="example@gmail.com", description="Email of the sender"
+    )
+    address: Optional[str] = Field(
+        None, example="123 Main St, Colombo 01", description="Address of the sender"
+    )
+    contactNo: Optional[str] = Field(
+        None, example="0771234567", description="Contact number of the sender"
+    )
+    created_at: datetime = Field(
+        ...,
+        example="2026-03-31T09:00:00Z",
+        description="ISO 8601 timestamp of when the sender was created",
+    )
+    updated_at: datetime = Field(
+        ...,
+        example="2026-03-31T09:00:00Z",
+        description="ISO 8601 timestamp of when the sender was last updated",
+    )
+
+class SenderListResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    # attributes
+    data: Sequence[SenderResponse] = Field([], description="List of senders.")
+    pagination: PaginationModel = Field(..., description="Pagination metadata.")

--- a/tool/backend/src/models/table_schemas/__init__.py
+++ b/tool/backend/src/models/table_schemas/__init__.py
@@ -1,7 +1,8 @@
-from .table_schemas import RTITemplate, Institution, Position
+from .table_schemas import RTITemplate, Institution, Position, Sender
 
 __all__ = [
     "RTITemplate",
     "Institution",
-    "Position"
+    "Position",
+    "Sender"
 ]

--- a/tool/backend/src/models/table_schemas/table_schemas.py
+++ b/tool/backend/src/models/table_schemas/table_schemas.py
@@ -64,14 +64,15 @@ class Sender(SQLModel, table=True):
     # table fields
     id: UUID = Field(primary_key=True, description="Unique identifier for the sender")
     name: str = Field(index=True, description="Name of the sender")
-    email: Optional[str] = Field(None, description="Email of the sender")
+    email: Optional[str] = Field(None, unique=True, description="Email of the sender")
     address: Optional[str] = Field(None, description="Address of the sender")
-    contact_no: Optional[str] = Field(None, description="Contact number of the sender")
+    contact_no: Optional[str] = Field(None, unique=True, description="Contact number of the sender")
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         description="ISO 8601 timestamp of when the sender was created",
     )
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
+        sa_column_kwargs={"onupdate": lambda: datetime.now(timezone.utc)},
         description="ISO 8601 timestamp of when the sender was last updated",
     )

--- a/tool/backend/src/models/table_schemas/table_schemas.py
+++ b/tool/backend/src/models/table_schemas/table_schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
-from sqlmodel import SQLModel, Field, func
+from sqlmodel import SQLModel, Field, func, CheckConstraint
 
 class RTITemplate(SQLModel, table=True):
     __tablename__ = "rti_templates"
@@ -39,3 +39,25 @@ class Position(SQLModel, table=True):
         sa_column_kwargs={"onupdate": lambda: datetime.now(timezone.utc)},
         description="ISO 8601 timestamp of when the position was last updated"
     )
+
+
+class Sender(SQLModel, table=True):
+    __tablename__ = "senders"
+
+    __table_args__ = (
+        CheckConstraint(
+            "email IS NOT NULL OR contactNo IS NOT NULL",
+            name="check_email_or_contact"
+        ),
+    )
+    # table fields
+    id: UUID = Field(primary_key=True, description="Unique identifier for the sender")
+    name: str = Field(index=True, description="Name of the sender")
+    email: Optional[str] = Field(None, description="Email of the sender")
+    address: Optional[str] = Field(None, description="Address of the sender")
+    contactNo: Optional[str] = Field(None, description="Contact number of the sender")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the sender was created")
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the sender was last updated")
+    
+
+

--- a/tool/backend/src/models/table_schemas/table_schemas.py
+++ b/tool/backend/src/models/table_schemas/table_schemas.py
@@ -3,16 +3,28 @@ from typing import Optional
 from uuid import UUID
 from sqlmodel import SQLModel, Field, func, CheckConstraint
 
+
 class RTITemplate(SQLModel, table=True):
     __tablename__ = "rti_templates"
 
     # table fields
-    id: UUID = Field(primary_key=True, description="Unique identifier for the RTI template")
+    id: UUID = Field(
+        primary_key=True, description="Unique identifier for the RTI template"
+    )
     title: str = Field(index=True, unique=True, description="Title of the RTI template")
-    description: Optional[str] = Field(None, description="Detailed description of the RTI template")
+    description: Optional[str] = Field(
+        None, description="Detailed description of the RTI template"
+    )
     file: str = Field(..., description="URL of the RTI template markdown file")
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the template was created")
-    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the template was last updated")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="ISO 8601 timestamp of when the template was created",
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="ISO 8601 timestamp of when the template was last updated",
+    )
+
 
 class Institution(SQLModel, table=True):
     __tablename__ = "institutions"
@@ -46,8 +58,7 @@ class Sender(SQLModel, table=True):
 
     __table_args__ = (
         CheckConstraint(
-            "email IS NOT NULL OR contactNo IS NOT NULL",
-            name="check_email_or_contact"
+            "email IS NOT NULL OR contact_no IS NOT NULL", name="check_email_or_contact"
         ),
     )
     # table fields
@@ -55,9 +66,12 @@ class Sender(SQLModel, table=True):
     name: str = Field(index=True, description="Name of the sender")
     email: Optional[str] = Field(None, description="Email of the sender")
     address: Optional[str] = Field(None, description="Address of the sender")
-    contactNo: Optional[str] = Field(None, description="Contact number of the sender")
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the sender was created")
-    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="ISO 8601 timestamp of when the sender was last updated")
-    
-
-
+    contact_no: Optional[str] = Field(None, description="Contact number of the sender")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="ISO 8601 timestamp of when the sender was created",
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="ISO 8601 timestamp of when the sender was last updated",
+    )

--- a/tool/backend/src/routers/__init__.py
+++ b/tool/backend/src/routers/__init__.py
@@ -1,10 +1,12 @@
 from .rti_template_router import router as rti_template_router
 from .institution_router import router as institution_router
 from .position_router import router as position_router
+from .sender_router import router as sender_router
 
 
 __all__ = [
     "rti_template_router",
     "institution_router",
-    "position_router"
+    "position_router",
+    "sender_router"
 ]

--- a/tool/backend/src/routers/sender_router.py
+++ b/tool/backend/src/routers/sender_router.py
@@ -9,11 +9,11 @@ def get_sender_service(session: SessionDep):
     return SenderService(session)
 
 @router.post("/senders", response_model=SenderResponse)
-async def create_rti_templates_endpoint(
+async def create_sender_endpoint(
     sender_request: SenderRequest,
     service: SenderService = Depends(get_sender_service)
 ):
-    return service.create_sender(template_request=sender_request)
+    return service.create_sender(sender_request=sender_request)
 
 
 

--- a/tool/backend/src/routers/sender_router.py
+++ b/tool/backend/src/routers/sender_router.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends
+from src.services import SenderService
+from src.repositories.db import SessionDep
+from src.models import SenderResponse, SenderRequest
+
+router = APIRouter(prefix="/api/v1", tags=["Senders"])
+
+def get_sender_service(session: SessionDep):
+    return SenderService(session)
+
+@router.post("/senders", response_model=SenderResponse)
+async def create_rti_templates_endpoint(
+    sender_request: SenderRequest,
+    service: SenderService = Depends(get_sender_service)
+):
+    return service.create_sender(template_request=sender_request)
+
+
+

--- a/tool/backend/src/routers/sender_router.py
+++ b/tool/backend/src/routers/sender_router.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter, Depends
 from src.services import SenderService
 from src.repositories.db import SessionDep
 from src.models import SenderResponse, SenderRequest
+from src.models import User, UserRole
+from src.dependencies import RoleChecker
 
 router = APIRouter(prefix="/api/v1", tags=["Senders"])
 
@@ -11,6 +13,7 @@ def get_sender_service(session: SessionDep):
 @router.post("/senders", response_model=SenderResponse)
 async def create_sender_endpoint(
     sender_request: SenderRequest,
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER])),
     service: SenderService = Depends(get_sender_service)
 ):
     return service.create_sender(sender_request=sender_request)

--- a/tool/backend/src/routers/sender_router.py
+++ b/tool/backend/src/routers/sender_router.py
@@ -13,8 +13,8 @@ def get_sender_service(session: SessionDep):
 @router.post("/senders", response_model=SenderResponse)
 async def create_sender_endpoint(
     sender_request: SenderRequest,
-    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER])),
-    service: SenderService = Depends(get_sender_service)
+    service: SenderService = Depends(get_sender_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     return service.create_sender(sender_request=sender_request)
 

--- a/tool/backend/src/services/__init__.py
+++ b/tool/backend/src/services/__init__.py
@@ -2,10 +2,12 @@ from .rti_template_service import RTITemplateService
 from .position_service import PositionService
 from .auth_service import AuthService
 from .github_file_service import GithubFileService
+from .sender_service import SenderService
 
 __all__ = [
     "RTITemplateService",
     "AuthService",
     "GithubFileService",
-    "PositionService"
+    "PositionService",
+    "SenderService"
 ]

--- a/tool/backend/src/services/sender_service.py
+++ b/tool/backend/src/services/sender_service.py
@@ -1,8 +1,10 @@
 from sqlmodel import Session
 from src.models import SenderRequest, SenderResponse, Sender
-from src.core.exceptions import InternalServerException, BadRequestException
+from src.core.exceptions import InternalServerException, BadRequestException, ConflictException
 from uuid import uuid4
 import logging
+from sqlalchemy.exc import IntegrityError
+import psycopg2
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +39,22 @@ class SenderService:
 
             return SenderResponse.model_validate(sender)
 
+        except IntegrityError as e:
+            self.session.rollback()
+            # detect unique constraint
+            if isinstance(e.orig, psycopg2.errors.UniqueViolation):
+                constraint = e.orig.diag.constraint_name
+
+                if constraint == "senders_email_key":
+                    raise ConflictException("Email already exists")
+
+                elif constraint == "senders_contact_no_key":
+                    raise ConflictException("Contact number already exists")
+
+                else:
+                    raise ConflictException("Duplicate values violates unique constraint")
+
+            raise
         except BadRequestException:
             raise
         except Exception as e:

--- a/tool/backend/src/services/sender_service.py
+++ b/tool/backend/src/services/sender_service.py
@@ -6,21 +6,18 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class SenderService:
     """
     This service is responsible for executing all sender related operations
     """
 
-    def __init__ (self, session: Session):
+    def __init__(self, session: Session):
         self.session = session
-    
+
     # API
     # create sender
-    def create_sender(
-        self,
-        *,
-        template_request: SenderRequest
-    ) -> SenderResponse:
+    def create_sender(self, *, template_request: SenderRequest) -> SenderResponse:
         try:
             # generate a uuid
             unique_id = uuid4()
@@ -31,7 +28,7 @@ class SenderService:
                 name=template_request.name,
                 email=template_request.email,
                 address=template_request.address,
-                contactNo=template_request.contactNo
+                contact_no=template_request.contact_no,
             )
 
             self.session.add(sender)
@@ -45,6 +42,6 @@ class SenderService:
         except Exception as e:
             self.session.rollback()
             logger.error(f"[SENDER SERVICE] Error creating sender: {e}")
-            raise InternalServerException(f"[SENDER SERVICE] Failed to create sender: {e}") from e
-
-    
+            raise InternalServerException(
+                f"[SENDER SERVICE] Failed to create sender: {e}"
+            ) from e

--- a/tool/backend/src/services/sender_service.py
+++ b/tool/backend/src/services/sender_service.py
@@ -17,7 +17,7 @@ class SenderService:
 
     # API
     # create sender
-    def create_sender(self, *, template_request: SenderRequest) -> SenderResponse:
+    def create_sender(self, *, sender_request: SenderRequest) -> SenderResponse:
         try:
             # generate a uuid
             unique_id = uuid4()
@@ -25,10 +25,10 @@ class SenderService:
             # create sender
             sender = Sender(
                 id=unique_id,
-                name=template_request.name,
-                email=template_request.email,
-                address=template_request.address,
-                contact_no=template_request.contact_no,
+                name=sender_request.name,
+                email=sender_request.email,
+                address=sender_request.address,
+                contact_no=sender_request.contact_no,
             )
 
             self.session.add(sender)
@@ -43,5 +43,5 @@ class SenderService:
             self.session.rollback()
             logger.error(f"[SENDER SERVICE] Error creating sender: {e}")
             raise InternalServerException(
-                f"[SENDER SERVICE] Failed to create sender: {e}"
+                "[SENDER SERVICE] Failed to create sender"
             ) from e

--- a/tool/backend/src/services/sender_service.py
+++ b/tool/backend/src/services/sender_service.py
@@ -1,0 +1,50 @@
+from sqlmodel import Session
+from src.models import SenderRequest, SenderResponse, Sender
+from src.core.exceptions import InternalServerException, BadRequestException
+from uuid import uuid4
+import logging
+
+logger = logging.getLogger(__name__)
+
+class SenderService:
+    """
+    This service is responsible for executing all sender related operations
+    """
+
+    def __init__ (self, session: Session):
+        self.session = session
+    
+    # API
+    # create sender
+    async def create_sender(
+        self,
+        *,
+        template_request: SenderRequest
+    ) -> SenderResponse:
+        try:
+            # generate a uuid
+            unique_id = uuid4()
+
+            # create sender
+            sender = Sender(
+                id=unique_id,
+                name=template_request.name,
+                email=template_request.email,
+                address=template_request.address,
+                contactNo=template_request.contactNo
+            )
+
+            self.session.add(sender)
+            self.session.commit()
+            self.session.refresh(sender)
+
+            return SenderResponse.model_validate(sender)
+
+        except BadRequestException:
+            raise
+        except Exception as e:
+            self.session.rollback()
+            logger.error(f"[SENDER SERVICE] Error creating sender: {e}")
+            raise InternalServerException(f"[SENDER SERVICE] Failed to create sender: {e}") from e
+
+    

--- a/tool/backend/src/services/sender_service.py
+++ b/tool/backend/src/services/sender_service.py
@@ -42,19 +42,16 @@ class SenderService:
         except IntegrityError as e:
             self.session.rollback()
             # detect unique constraint
-            if isinstance(e.orig, psycopg2.errors.UniqueViolation):
-                constraint = e.orig.diag.constraint_name
+            constraint = e.orig.diag.constraint_name
 
-                if constraint == "senders_email_key":
-                    raise ConflictException("Email already exists")
+            if constraint == "senders_email_key":
+                raise ConflictException("Email already exists")
 
-                elif constraint == "senders_contact_no_key":
-                    raise ConflictException("Contact number already exists")
+            elif constraint == "senders_contact_no_key":
+                raise ConflictException("Contact number already exists")
 
-                else:
-                    raise ConflictException("Duplicate values violates unique constraint")
-
-            raise
+            else:
+                raise ConflictException("Duplicate values violates unique constraint")
         except BadRequestException:
             raise
         except Exception as e:

--- a/tool/backend/src/services/sender_service.py
+++ b/tool/backend/src/services/sender_service.py
@@ -1,13 +1,11 @@
 from sqlmodel import Session
 from src.models import SenderRequest, SenderResponse, Sender
-from src.core.exceptions import InternalServerException, BadRequestException, ConflictException
+from src.core.exceptions import InternalServerException, ConflictException
 from uuid import uuid4
 import logging
 from sqlalchemy.exc import IntegrityError
-import psycopg2
 
 logger = logging.getLogger(__name__)
-
 
 class SenderService:
     """
@@ -52,8 +50,6 @@ class SenderService:
 
             else:
                 raise ConflictException("Duplicate values violates unique constraint")
-        except BadRequestException:
-            raise
         except Exception as e:
             self.session.rollback()
             logger.error(f"[SENDER SERVICE] Error creating sender: {e}")

--- a/tool/backend/src/services/sender_service.py
+++ b/tool/backend/src/services/sender_service.py
@@ -16,7 +16,7 @@ class SenderService:
     
     # API
     # create sender
-    async def create_sender(
+    def create_sender(
         self,
         *,
         template_request: SenderRequest

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -12,6 +12,15 @@ from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 from src.services.auth_service import AuthService
 from src.utils import http_client
 
+from src.models.response_models import SenderResponse
+from src.models.request_models import SenderRequest
+from src.services import SenderService
+
+
+FIXED_UUID = uuid.UUID("123e4567-e89b-12d3-a456-426614174000")
+FIXED_NOW = datetime(2026, 3, 31, 9, 0, 0, tzinfo=timezone.utc)
+
+
 # MockResponse class to simulate aiohttp responses
 class MockResponse:
     def __init__(self, json_data, status=200):
@@ -31,14 +40,18 @@ class MockResponse:
     async def __aexit__(self, exc_type, exc, tb):
         pass
 
+
 # Fixture to patch http_client.session with a fake session
 @pytest.fixture
 def patch_http_client_session():
     """Yield a mock session and patch http_client.session"""
     fake_session = MagicMock()
-    with patch.object(type(http_client), "session", new_callable=PropertyMock) as mock_session_prop:
+    with patch.object(
+        type(http_client), "session", new_callable=PropertyMock
+    ) as mock_session_prop:
         mock_session_prop.return_value = fake_session
         yield fake_session
+
 
 # fixtures for RTI Templates
 @pytest.fixture
@@ -47,7 +60,7 @@ def in_memory_db():
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
     now = datetime.now(timezone.utc)
-    
+
     templates = [
         RTITemplate(
             id=uuid.uuid4(),
@@ -74,7 +87,7 @@ def in_memory_db():
             updated_at=now,
         ),
     ]
-    
+
     with Session(engine) as session:
         session.add_all(templates)
         session.commit()
@@ -85,6 +98,7 @@ def in_memory_db():
 @pytest.fixture
 def make_upload_file():
     """Returns a factory for creating mock UploadFile instances."""
+
     def _factory(
         content: bytes = b"# Hello",
         content_type: str = "text/markdown",
@@ -95,23 +109,27 @@ def make_upload_file():
         mock_file.filename = filename
         mock_file.read = AsyncMock(return_value=content)
         return mock_file
+
     return _factory
 
 
 @pytest.fixture
 def make_github_content_file():
     """Returns a factory for GitHub ContentFile mock objects."""
+
     def _factory(path: str) -> MagicMock:
         content_file = MagicMock()
         content_file.path = path
         content_file.sha = "abc123sha"
         return content_file
+
     return _factory
 
 
 @pytest.fixture
 def make_file_service():
     """Returns a factory for mock GithubFileService instances with configurable upload/delete behaviour."""
+
     def _factory(
         relative_path: str = "rti-templates/test-uuid.md",
         absolute_path: str = "https://github.com/org/repo/blob/main/rti-templates/test-uuid.md",
@@ -122,18 +140,22 @@ def make_file_service():
         if upload_side_effect:
             file_service.upload_file = AsyncMock(side_effect=upload_side_effect)
         else:
-            file_service.upload_file = AsyncMock(return_value={
-                "relative_path": relative_path,
-                "absolute_path": absolute_path,
-            })
+            file_service.upload_file = AsyncMock(
+                return_value={
+                    "relative_path": relative_path,
+                    "absolute_path": absolute_path,
+                }
+            )
         file_service.delete_file = AsyncMock(return_value=delete_return)
         return file_service
+
     return _factory
 
 
 @pytest.fixture
 def make_template_request():
     """Returns a factory for mock RTITemplateRequest instances with a fake UploadFile."""
+
     def _factory(
         title: str = "Test Template",
         description: str = "A test description",
@@ -148,6 +170,7 @@ def make_template_request():
         request.description = description
         request.file = mock_upload
         return request
+
     return _factory
 
 @pytest.fixture
@@ -221,3 +244,51 @@ def position_db():
         yield session
 
     
+
+# ── sender fixtures ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def make_sender_request():
+    """Factory for SenderRequest instances."""
+
+    def _factory(
+        name: str = "John Doe",
+        email: str | None = "john@example.com",
+        address: str | None = "123 Main St, Colombo 01",
+        contact_no: str | None = None,
+    ) -> SenderRequest:
+        return SenderRequest(
+            name=name, email=email, address=address, contact_no=contact_no
+        )
+
+    return _factory
+
+
+@pytest.fixture
+def make_sender_response():
+    """Factory for SenderResponse instances."""
+
+    def _factory(
+        id: uuid.UUID = FIXED_UUID,
+        name: str = "John Doe",
+        email: str | None = "john@example.com",
+        address: str | None = "123 Main St, Colombo 01",
+        contact_no: str | None = None,
+    ) -> SenderResponse:
+        return SenderResponse(
+            id=id,
+            name=name,
+            email=email,
+            address=address,
+            contact_no=contact_no,
+            created_at=FIXED_NOW,
+            updated_at=FIXED_NOW,
+        )
+
+    return _factory
+
+
+@pytest.fixture
+def mock_sender_service():
+    return MagicMock(spec=SenderService)

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -245,9 +245,7 @@ def position_db():
 
     
 
-# ── sender fixtures ───────────────────────────────────────────────────────────
-
-
+# sender fixtures 
 @pytest.fixture
 def make_sender_request():
     """Factory for SenderRequest instances."""

--- a/tool/backend/test/test_sender_service.py
+++ b/tool/backend/test/test_sender_service.py
@@ -146,13 +146,6 @@ def test_create_sender_rolls_back_on_db_error(monkeypatch, in_memory_db, make_se
         service.create_sender(sender_request=make_sender_request())
     rollback_mock.assert_called_once()
 
-def test_create_sender_reraises_bad_request_exception(monkeypatch, in_memory_db, make_sender_request):
-    service = SenderService(session=in_memory_db)
-    monkeypatch.setattr(in_memory_db, "add", MagicMock(side_effect=BadRequestException("duplicate")))
-
-    with pytest.raises(BadRequestException):
-        service.create_sender(sender_request=make_sender_request())
-
 # IntegrityError tests – SenderService.create_sender
 
 def _make_integrity_error(constraint_name: str):

--- a/tool/backend/test/test_sender_service.py
+++ b/tool/backend/test/test_sender_service.py
@@ -156,7 +156,7 @@ def test_create_sender_reraises_bad_request_exception(monkeypatch, in_memory_db,
 # IntegrityError tests – SenderService.create_sender
 
 def _make_integrity_error(constraint_name: str):
-    """Build a fake IntegrityError that looks like a psycopg2 UniqueViolation."""
+    """Build a fake IntegrityError that looks like an UniqueViolation."""
     diag = MagicMock()
     diag.constraint_name = constraint_name
 

--- a/tool/backend/test/test_sender_service.py
+++ b/tool/backend/test/test_sender_service.py
@@ -1,0 +1,196 @@
+import uuid
+from unittest.mock import MagicMock
+import pytest
+from pydantic import ValidationError
+from sqlmodel import select
+
+from src.models.response_models import SenderResponse
+from src.models.request_models import SenderRequest
+from src.core.exceptions import InternalServerException, BadRequestException
+from src.models import Sender
+from src.services import SenderService
+from datetime import datetime
+from sqlalchemy.exc import IntegrityError
+from src.core.exceptions import ConflictException
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unit tests – SenderRequest validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_sender_request_valid_with_email_only():
+    req = SenderRequest(name="Alice", email="alice@example.com")
+    assert req.email == "alice@example.com"
+    assert req.contact_no is None
+
+def test_sender_request_valid_with_contact_no_only():
+    req = SenderRequest(name="Bob", contact_no="0771234567")
+    assert req.contact_no == "0771234567"
+    assert req.email is None
+
+def test_sender_request_valid_with_both_fields():
+    req = SenderRequest(name="Carol", email="carol@example.com", contact_no="0771234567")
+    assert req.email == "carol@example.com"
+    assert req.contact_no == "0771234567"
+
+def test_sender_request_raises_when_neither_email_nor_contact_no():
+    with pytest.raises(BadRequestException) as exc_info:
+        SenderRequest(name="Ghost")
+    assert exc_info.value.message == "Either email or contact_no must be provided."
+
+def test_sender_request_raises_on_invalid_email_format():
+    with pytest.raises(ValidationError) as exc_info:
+        SenderRequest(name="Bad Email", email="not-an-email")
+    errors = exc_info.value.errors()
+    assert errors[0]["type"] == "value_error"
+    assert "email" in errors[0]["loc"]
+
+def test_sender_request_strips_whitespace_from_name():
+    req = SenderRequest(name="  Jane  ", email="jane@example.com")
+    assert req.name == "Jane"
+
+def test_sender_request_optional_fields_default_to_none():
+    req = SenderRequest(name="Min", email="min@example.com")
+    assert req.address is None
+    assert req.contact_no is None
+
+def test_send_invalid_contact_no():
+    with pytest.raises(ValidationError) as exc_info:
+        SenderRequest(name="Bad Contact No", contact_no=123443)
+    errors = exc_info.value.errors()
+    assert errors[0]["type"] == "string_type"
+    assert "contact_no" in errors[0]["loc"]
+
+def test_send_invalid_name():
+    with pytest.raises(ValidationError) as exc_info:
+        SenderRequest(name=123443, contact_no="0771234567")
+    errors = exc_info.value.errors()
+    assert errors[0]["type"] == "string_type"
+    assert "name" in errors[0]["loc"]
+
+def test_send_invalid_address():
+    with pytest.raises(ValidationError) as exc_info:
+        SenderRequest(name="Bad Contact No",address=123443 ,contact_no="0771234567")
+    errors = exc_info.value.errors()
+    assert errors[0]["type"] == "string_type"
+    assert "address" in errors[0]["loc"]
+
+def test_send_good_request():
+    req = SenderRequest(name="Good Request", email="example@gmail.com", contact_no="0771234567", address="123 Main St, Colombo 01")
+    assert req.name == "Good Request"
+    assert req.email == "example@gmail.com"
+    assert req.contact_no == "0771234567"
+    assert req.address == "123 Main St, Colombo 01"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unit tests – SenderService.create_sender
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_create_sender_with_email_returns_response(in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    result = service.create_sender(sender_request=make_sender_request())
+
+    assert isinstance(result, SenderResponse)
+    assert result.name == "John Doe"
+    assert result.email == "john@example.com"
+    assert isinstance(result.id, uuid.UUID)
+
+def test_create_sender_with_contact_no_returns_response(in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    result = service.create_sender(
+        sender_request=make_sender_request(email=None, contact_no="0771234567")
+    )
+
+    assert result.contact_no == "0771234567"
+    assert result.email is None
+
+def test_create_sender_with_all_fields(in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    result = service.create_sender(
+        sender_request=make_sender_request(
+            email="john@example.com",
+            address="123 Main St, Colombo 01",
+            contact_no="0771234567",
+        )
+    )
+
+    assert result.name == "John Doe"
+    assert result.address == "123 Main St, Colombo 01"
+    assert result.email == "john@example.com"
+    assert result.contact_no == "0771234567"
+
+def test_create_sender_persists_to_db(in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    result = service.create_sender(sender_request=make_sender_request())
+
+    db_record = in_memory_db.exec(select(Sender).where(Sender.id == result.id)).first()
+    assert db_record is not None
+    assert db_record.name == "John Doe"
+    assert db_record.email == "john@example.com"
+
+def test_create_sender_response_has_timestamps(in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    result = service.create_sender(sender_request=make_sender_request())
+
+    assert isinstance(result.created_at, datetime)
+    assert isinstance(result.updated_at, datetime)
+
+def test_create_sender_raises_internal_on_db_error(monkeypatch, in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=Exception("DB failure")))
+
+    with pytest.raises(InternalServerException):
+        service.create_sender(sender_request=make_sender_request())
+
+def test_create_sender_rolls_back_on_db_error(monkeypatch, in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    rollback_mock = MagicMock()
+    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=Exception("DB failure")))
+    monkeypatch.setattr(in_memory_db, "rollback", rollback_mock)
+
+    with pytest.raises(InternalServerException):
+        service.create_sender(sender_request=make_sender_request())
+    rollback_mock.assert_called_once()
+
+def test_create_sender_reraises_bad_request_exception(monkeypatch, in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    monkeypatch.setattr(in_memory_db, "add", MagicMock(side_effect=BadRequestException("duplicate")))
+
+    with pytest.raises(BadRequestException):
+        service.create_sender(sender_request=make_sender_request())
+
+# ─────────────────────────────────────────────────────────────────────────────
+# IntegrityError tests – SenderService.create_sender
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_integrity_error(constraint_name: str):
+    """Build a fake IntegrityError that looks like a psycopg2 UniqueViolation."""
+    import psycopg2.errors
+    orig = MagicMock(spec=psycopg2.errors.UniqueViolation)
+    orig.diag.constraint_name = constraint_name
+    return IntegrityError(statement=None, params=None, orig=orig)
+
+def test_create_sender_raises_conflict_on_duplicate_email(monkeypatch, in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=_make_integrity_error("senders_email_key")))
+
+    with pytest.raises(ConflictException) as exc_info:
+        service.create_sender(sender_request=make_sender_request())
+    assert "Email" in exc_info.value.message
+
+def test_create_sender_raises_conflict_on_duplicate_contact_no(monkeypatch, in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=_make_integrity_error("senders_contact_no_key")))
+
+    with pytest.raises(ConflictException) as exc_info:
+        service.create_sender(sender_request=make_sender_request(email=None, contact_no="0771234567"))
+    assert "Contact" in exc_info.value.message
+
+def test_create_sender_rolls_back_on_integrity_error(monkeypatch, in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+    rollback_mock = MagicMock()
+    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=_make_integrity_error("senders_email_key")))
+    monkeypatch.setattr(in_memory_db, "rollback", rollback_mock)
+
+    with pytest.raises(ConflictException):
+        service.create_sender(sender_request=make_sender_request())
+    rollback_mock.assert_called_once()

--- a/tool/backend/test/test_sender_service.py
+++ b/tool/backend/test/test_sender_service.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import ValidationError
 from sqlmodel import select
-
 from src.models.response_models import SenderResponse
 from src.models.request_models import SenderRequest
 from src.core.exceptions import InternalServerException, BadRequestException
@@ -13,9 +12,7 @@ from datetime import datetime
 from sqlalchemy.exc import IntegrityError
 from src.core.exceptions import ConflictException
 
-# ─────────────────────────────────────────────────────────────────────────────
 # Unit tests – SenderRequest validation
-# ─────────────────────────────────────────────────────────────────────────────
 
 def test_sender_request_valid_with_email_only():
     req = SenderRequest(name="Alice", email="alice@example.com")
@@ -81,9 +78,7 @@ def test_send_good_request():
     assert req.contact_no == "0771234567"
     assert req.address == "123 Main St, Colombo 01"
 
-# ─────────────────────────────────────────────────────────────────────────────
 # Unit tests – SenderService.create_sender
-# ─────────────────────────────────────────────────────────────────────────────
 
 def test_create_sender_with_email_returns_response(in_memory_db, make_sender_request):
     service = SenderService(session=in_memory_db)
@@ -158,15 +153,15 @@ def test_create_sender_reraises_bad_request_exception(monkeypatch, in_memory_db,
     with pytest.raises(BadRequestException):
         service.create_sender(sender_request=make_sender_request())
 
-# ─────────────────────────────────────────────────────────────────────────────
 # IntegrityError tests – SenderService.create_sender
-# ─────────────────────────────────────────────────────────────────────────────
 
 def _make_integrity_error(constraint_name: str):
     """Build a fake IntegrityError that looks like a psycopg2 UniqueViolation."""
-    import psycopg2.errors
-    orig = MagicMock(spec=psycopg2.errors.UniqueViolation)
-    orig.diag.constraint_name = constraint_name
+    diag = MagicMock()
+    diag.constraint_name = constraint_name
+
+    orig = MagicMock()
+    orig.diag = diag
     return IntegrityError(statement=None, params=None, orig=orig)
 
 def test_create_sender_raises_conflict_on_duplicate_email(monkeypatch, in_memory_db, make_sender_request):
@@ -193,4 +188,17 @@ def test_create_sender_rolls_back_on_integrity_error(monkeypatch, in_memory_db, 
 
     with pytest.raises(ConflictException):
         service.create_sender(sender_request=make_sender_request())
+    rollback_mock.assert_called_once()
+
+def test_create_sender_integrity_error_default_fallback(monkeypatch, in_memory_db, make_sender_request):
+    service = SenderService(session=in_memory_db)
+
+    rollback_mock = MagicMock()
+    monkeypatch.setattr(in_memory_db, "commit", MagicMock(side_effect=_make_integrity_error("unknown_constraint")))
+    monkeypatch.setattr(in_memory_db, "rollback", rollback_mock)
+
+    with pytest.raises(ConflictException) as exc:
+        service.create_sender(sender_request=make_sender_request())
+
+    assert "Duplicate values violates unique constraint" in str(exc.value)
     rollback_mock.assert_called_once()

--- a/tool/backend/uv.lock
+++ b/tool/backend/uv.lock
@@ -136,6 +136,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -152,6 +153,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.5" },
+    { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.135.3" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -348,6 +350,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
     { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
     { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR has implemented the `/sender` creation endpoint according to the pre-agreed contract.

**Note**: Had to update a field name on the contract due to a mismatching with the DB table column names. `contactNo` is changed to `contact_no`.

**Note**: in the `SenderRequest` , `oneOf` is changed to `anyOf` to allow multiple applicable conditions instead of restricting validation to exactly one schema match.

**Note**: migrated the ErrorResponse from `models` to `core` as a solution to the circular import error. (making the `core` independent)

**Note**: updated the `exception` class with new custom exceptions for `pydantic` validation errors. and proper error mapping messages for DB constraints.

This PR Closes #43 