### PR TITLE
GH-72: [RTI][TOOL][BACKEND] Institution Management APIs

### DIFF
--- a/tool/backend/src/models/request_models/__init__.py
+++ b/tool/backend/src/models/request_models/__init__.py
@@ -1,8 +1,10 @@
 from .senders import SenderRequest
 from .rti_templates import RTITemplateRequest
+from .institutions import InstitutionRequest
 
 __all__ = [
     "SenderRequest",
-    "RTITemplateRequest"
+    "RTITemplateRequest",
+    "InstitutionRequest"
 ]
 

--- a/tool/backend/src/models/request_models/institutions.py
+++ b/tool/backend/src/models/request_models/institutions.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+class InstitutionRequest(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    # attributes
+    name: str = Field(..., json_schema_extra={"example":"Institution X"}, description="Name of the institution.")
+

--- a/tool/backend/src/models/request_models/institutions.py
+++ b/tool/backend/src/models/request_models/institutions.py
@@ -3,5 +3,5 @@ from pydantic import BaseModel, ConfigDict, Field
 class InstitutionRequest(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
     # attributes
-    name: str = Field(..., json_schema_extra={"example":"Institution X"}, description="Name of the institution.")
+    name: str = Field(..., min_length=1, json_schema_extra={"example":"Institution X"}, description="Name of the institution.")
 

--- a/tool/backend/src/routers/institution_router.py
+++ b/tool/backend/src/routers/institution_router.py
@@ -1,5 +1,6 @@
 from fastapi import Path
 from typing import Annotated
+from uuid import UUID
 from src.models.request_models import InstitutionRequest
 from src.services.institution_service import InstitutionService
 from src.repositories.db import SessionDep
@@ -26,7 +27,7 @@ def get_institutions_endpoint(
 
 @router.get("/institutions/{institution_id}", response_model=InstitutionResponse)
 def get_institution_endpoint(
-    institution_id: Annotated[str, Path(title="ID of the institution")],
+    institution_id: Annotated[UUID, Path(title="ID of the institution")],
     service: InstitutionService = Depends(get_institution_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
@@ -44,17 +45,17 @@ def create_institution_endpoint(
 
 @router.put("/institutions/{institution_id}", response_model=InstitutionResponse)
 def update_institution_endpoint(
-    institution_id: Annotated[str, Path(title="ID of the institution")],
+    institution_id: Annotated[UUID, Path(title="ID of the institution")],
     request: InstitutionRequest,
     service: InstitutionService = Depends(get_institution_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
-    response = service.update_institution(institution_id=institution_id,request=request)
+    response = service.update_institution(institution_id=institution_id, request=request)
     return response
 
 @router.delete("/institutions/{institution_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_institution_endpoint(
-    institution_id: Annotated[str, Path(title="ID of the institution")],
+    institution_id: Annotated[UUID, Path(title="ID of the institution")],
     service: InstitutionService = Depends(get_institution_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):

--- a/tool/backend/src/routers/institution_router.py
+++ b/tool/backend/src/routers/institution_router.py
@@ -1,6 +1,7 @@
+from src.models.request_models import InstitutionRequest
 from src.services.institution_service import InstitutionService
 from src.repositories.db import SessionDep
-from src.models.response_models import InstitutionListResponse
+from src.models.response_models import InstitutionListResponse, InstitutionResponse
 from src.dependencies import RoleChecker
 from src.models import UserRole, User
 from fastapi import Depends, Query
@@ -19,4 +20,13 @@ def get_institutions_endpoint(
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
     ):
     response = service.get_institutions(page=page, page_size=page_size)
+    return response
+
+@router.post("/institutions", response_model=InstitutionResponse)
+def create_institutions_endpoint(
+    request: InstitutionRequest,
+    service: InstitutionService = Depends(get_institution_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+):  
+    response = service.create_institutions(request=request)
     return response

--- a/tool/backend/src/routers/institution_router.py
+++ b/tool/backend/src/routers/institution_router.py
@@ -1,3 +1,5 @@
+from fastapi import Path
+from typing import Annotated
 from src.models.request_models import InstitutionRequest
 from src.services.institution_service import InstitutionService
 from src.repositories.db import SessionDep
@@ -21,6 +23,16 @@ def get_institutions_endpoint(
     ):
     response = service.get_institutions(page=page, page_size=page_size)
     return response
+
+@router.get("/institutions/{id}", response_model=InstitutionResponse)
+def get_institution_by_id_endpoint(
+    id: Annotated[str, Path(title="ID of the institution")],
+    service: InstitutionService = Depends(get_institution_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+):
+    response = service.get_institution_by_id(institution_id=id)
+    return response
+
 
 @router.post("/institutions", response_model=InstitutionResponse)
 def create_institutions_endpoint(

--- a/tool/backend/src/routers/institution_router.py
+++ b/tool/backend/src/routers/institution_router.py
@@ -6,7 +6,7 @@ from src.repositories.db import SessionDep
 from src.models.response_models import InstitutionListResponse, InstitutionResponse
 from src.dependencies import RoleChecker
 from src.models import UserRole, User
-from fastapi import Depends, Query
+from fastapi import Depends, Query, status
 from fastapi.routing import APIRouter
 
 router = APIRouter(prefix="/api/v1", tags=["Institutions"])
@@ -24,30 +24,40 @@ def get_institutions_endpoint(
     response = service.get_institutions(page=page, page_size=page_size)
     return response
 
-@router.get("/institutions/{id}", response_model=InstitutionResponse)
-def get_institution_by_id_endpoint(
-    id: Annotated[str, Path(title="ID of the institution")],
+@router.get("/institutions/{institution_id}", response_model=InstitutionResponse)
+def get_institution_endpoint(
+    institution_id: Annotated[str, Path(title="ID of the institution")],
     service: InstitutionService = Depends(get_institution_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
-    response = service.get_institution_by_id(institution_id=id)
+    response = service.get_institution(institution_id=institution_id)
     return response
 
 @router.post("/institutions", response_model=InstitutionResponse)
-def create_institutions_endpoint(
+def create_institution_endpoint(
     request: InstitutionRequest,
     service: InstitutionService = Depends(get_institution_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):  
-    response = service.create_institutions(request=request)
+    response = service.create_institution(request=request)
     return response
 
-@router.put("/rti_templates/{id}")
-async def update_rti_template_endpoint(
-    id: Annotated[str, Path(title="ID of the institution")],
+@router.put("/institutions/{institution_id}", response_model=InstitutionResponse)
+def update_institution_endpoint(
+    institution_id: Annotated[str, Path(title="ID of the institution")],
     request: InstitutionRequest,
     service: InstitutionService = Depends(get_institution_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
-    response = service.update_institution(institution_id=id,request=request)
+    response = service.update_institution(institution_id=institution_id,request=request)
     return response
+
+@router.delete("/institutions/{institution_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_institution_endpoint(
+    institution_id: Annotated[str, Path(title="ID of the institution")],
+    service: InstitutionService = Depends(get_institution_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+):
+    service.delete_institution(institution_id=institution_id)
+    return None
+

--- a/tool/backend/src/routers/institution_router.py
+++ b/tool/backend/src/routers/institution_router.py
@@ -33,7 +33,6 @@ def get_institution_by_id_endpoint(
     response = service.get_institution_by_id(institution_id=id)
     return response
 
-
 @router.post("/institutions", response_model=InstitutionResponse)
 def create_institutions_endpoint(
     request: InstitutionRequest,
@@ -41,4 +40,14 @@ def create_institutions_endpoint(
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):  
     response = service.create_institutions(request=request)
+    return response
+
+@router.put("/rti_templates/{id}")
+async def update_rti_template_endpoint(
+    id: Annotated[str, Path(title="ID of the institution")],
+    request: InstitutionRequest,
+    service: InstitutionService = Depends(get_institution_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
+):
+    response = service.update_institution(institution_id=id,request=request)
     return response

--- a/tool/backend/src/services/institution_service.py
+++ b/tool/backend/src/services/institution_service.py
@@ -81,7 +81,8 @@ class InstitutionService:
     def create_institutions(
         self,
         *,
-        request):
+        request
+    ):
         try:
             unique_id = uuid4()
 
@@ -107,3 +108,40 @@ class InstitutionService:
             self.session.rollback()
             logger.error(f"[INSTITUTION SERVICE] Error creating institution: {e}")
             raise InternalServerException("Failed to create Institution") from e
+
+    # API
+    def update_institution(
+        self,
+        *,
+        institution_id,
+        request
+    ):
+        try:
+            target_id = UUID(institution_id) if isinstance(institution_id, str) else institution_id
+        except ValueError:
+            raise BadRequestException(f"Invalid UUID format: {institution_id}")
+
+        institution = self.session.get(Institution, target_id)
+
+        if not institution:
+            raise NotFoundException(f"Institution with id {institution_id} not found.")
+        
+        try:
+            institution.name = request.name      
+
+            self.session.add(institution)
+            self.session.commit()
+            self.session.refresh(institution)
+
+            return InstitutionResponse.model_validate(institution)
+
+        except Exception as e:
+            self.session.rollback()
+
+            if isinstance(e, IntegrityError):
+                logger.error(f"[INSTITUTION SERVICE] Duplicate institution error updating Institution: {e}")
+                raise ConflictException("Institution with this name already exists.") from e
+
+            logger.error(f"[INSTITUTION SERVICE] Error updating Institution: {e}")
+            raise InternalServerException(f"Failed to update Institution: {e}") from e
+

--- a/tool/backend/src/services/institution_service.py
+++ b/tool/backend/src/services/institution_service.py
@@ -74,7 +74,7 @@ class InstitutionService:
             raise
         except Exception as e:
             logger.error(f"[INSTITUTION SERVICE] Error reading Institution: {e}")
-            raise InternalServerException(f"Failed to read Insitution: {e}") from e
+            raise InternalServerException(f"Failed to read Institution") from e
     
     # API
     def create_institution(
@@ -85,7 +85,7 @@ class InstitutionService:
         try:
             unique_id = uuid4()
 
-            # insitution object to store in the DB
+            # institution object to store in the DB
             institution = Institution(
                 id=unique_id,
                 name=request.name
@@ -101,7 +101,7 @@ class InstitutionService:
         except IntegrityError as e:
             self.session.rollback()
             logger.error(f"[INSTITUTION SERVICE] Error creating institution: {e}")
-            raise ConflictException("Institution with this name already exists.") from e
+            raise ConflictException("Institution with this name already exists") from e
 
         except Exception as e:
             self.session.rollback()
@@ -139,10 +139,10 @@ class InstitutionService:
 
             if isinstance(e, IntegrityError):
                 logger.error(f"[INSTITUTION SERVICE] Duplicate institution error updating Institution: {e}")
-                raise ConflictException("Institution with this name already exists.") from e
+                raise ConflictException("Institution with this name already exists") from e
 
             logger.error(f"[INSTITUTION SERVICE] Error updating Institution: {e}")
-            raise InternalServerException(f"Failed to update Institution: {e}") from e
+            raise InternalServerException(f"Failed to update Institution") from e
 
     # API
     def delete_institution(
@@ -175,6 +175,6 @@ class InstitutionService:
         except Exception as e:
             self.session.rollback()
             logger.error(f"[INSTITUTION SERVICE] Error deleting Institution: {e}")
-            raise InternalServerException(f"Failed to delete Institution: {e}") from e
+            raise InternalServerException(f"Failed to delete Institution") from e
         
         

--- a/tool/backend/src/services/institution_service.py
+++ b/tool/backend/src/services/institution_service.py
@@ -1,9 +1,9 @@
-from uuid import uuid4
+from uuid import uuid4, UUID
 import logging
 from src.models import PaginationModel, Institution
 from src.models.response_models import InstitutionListResponse, InstitutionResponse
 from src.models.table_schemas import Institution
-from src.core.exceptions import InternalServerException, ConflictException
+from src.core.exceptions import InternalServerException, ConflictException, NotFoundException, BadRequestException
 from sqlmodel import Session, select, func
 from sqlalchemy.exc import IntegrityError
 
@@ -49,8 +49,33 @@ class InstitutionService:
                 pagination=pagination
             )
         except Exception as e:
-            logger.error(f"Error fetching Institutions: {e}")
+            logger.error(f"[INSTITUTION SERVICE] Error fetching Institutions: {e}")
             raise InternalServerException("Failed to fetch Institutions from database.") from e
+    
+    # API
+    def get_institution_by_id(
+        self,
+        *,
+        institution_id
+    ) -> InstitutionResponse:
+        try:
+            try:
+                target_id = UUID(institution_id) if isinstance(institution_id, str) else institution_id
+            except ValueError:
+                raise BadRequestException(f"Invalid UUID format: {institution_id}")
+
+            institution = self.session.get(Institution, target_id)
+
+            if not institution:
+                raise NotFoundException(f"Institution with id {institution_id} not found.")
+
+            return InstitutionResponse.model_validate(institution)
+
+        except (BadRequestException, NotFoundException):
+            raise
+        except Exception as e:
+            logger.error(f"[INSTITUTION SERVICE] Error reading Institution: {e}")
+            raise InternalServerException(f"Failed to read Insitution: {e}") from e
     
     # API
     def create_institutions(
@@ -75,10 +100,10 @@ class InstitutionService:
 
         except IntegrityError as e:
             self.session.rollback()
-            logger.error(f"Error creating institution: {e}")
+            logger.error(f"[INSTITUTION SERVICE] Error creating institution: {e}")
             raise ConflictException("Duplicate values violates unique constraint") from e
 
         except Exception as e:
             self.session.rollback()
-            logger.error(f"Error creating institution: {e}")
+            logger.error(f"[INSTITUTION SERVICE] Error creating institution: {e}")
             raise InternalServerException("Failed to create Institution") from e

--- a/tool/backend/src/services/institution_service.py
+++ b/tool/backend/src/services/institution_service.py
@@ -1,8 +1,7 @@
-from uuid import uuid4, UUID
 import logging
+from uuid import uuid4, UUID
 from src.models import PaginationModel, Institution
 from src.models.response_models import InstitutionListResponse, InstitutionResponse
-from src.models.table_schemas import Institution
 from src.core.exceptions import InternalServerException, ConflictException, NotFoundException, BadRequestException
 from sqlmodel import Session, select, func
 from sqlalchemy.exc import IntegrityError
@@ -53,7 +52,7 @@ class InstitutionService:
             raise InternalServerException("Failed to fetch Institutions from database.") from e
     
     # API
-    def get_institution_by_id(
+    def get_institution(
         self,
         *,
         institution_id
@@ -78,11 +77,11 @@ class InstitutionService:
             raise InternalServerException(f"Failed to read Insitution: {e}") from e
     
     # API
-    def create_institutions(
+    def create_institution(
         self,
         *,
         request
-    ):
+    ) -> InstitutionResponse:
         try:
             unique_id = uuid4()
 
@@ -102,7 +101,7 @@ class InstitutionService:
         except IntegrityError as e:
             self.session.rollback()
             logger.error(f"[INSTITUTION SERVICE] Error creating institution: {e}")
-            raise ConflictException("Duplicate values violates unique constraint") from e
+            raise ConflictException("Institution with this name already exists.") from e
 
         except Exception as e:
             self.session.rollback()
@@ -115,7 +114,7 @@ class InstitutionService:
         *,
         institution_id,
         request
-    ):
+    ) -> InstitutionResponse:
         try:
             target_id = UUID(institution_id) if isinstance(institution_id, str) else institution_id
         except ValueError:
@@ -145,3 +144,37 @@ class InstitutionService:
             logger.error(f"[INSTITUTION SERVICE] Error updating Institution: {e}")
             raise InternalServerException(f"Failed to update Institution: {e}") from e
 
+    # API
+    def delete_institution(
+        self,
+        *,
+        institution_id
+    ) -> None:
+        try:
+            target_id = UUID(institution_id) if isinstance(institution_id, str) else institution_id
+        except ValueError:
+            raise BadRequestException(f"Invalid UUID format: {institution_id}")
+
+        institution = self.session.get(Institution, target_id)
+
+        if not institution:
+            raise NotFoundException(f"Institution with id {institution_id} not found.")
+        
+        try:
+            # Delete record from DB
+            self.session.delete(institution)
+            self.session.commit()
+            return None
+
+        except IntegrityError:
+            self.session.rollback()
+            raise ConflictException("Cannot delete Institution because it is used in existing records.")
+
+        except (BadRequestException, NotFoundException, ConflictException):
+            raise
+        except Exception as e:
+            self.session.rollback()
+            logger.error(f"[INSTITUTION SERVICE] Error deleting Institution: {e}")
+            raise InternalServerException(f"Failed to delete Institution: {e}") from e
+        
+        

--- a/tool/backend/src/services/institution_service.py
+++ b/tool/backend/src/services/institution_service.py
@@ -1,9 +1,11 @@
+from uuid import uuid4
 import logging
-from src.models import PaginationModel
+from src.models import PaginationModel, Institution
 from src.models.response_models import InstitutionListResponse, InstitutionResponse
 from src.models.table_schemas import Institution
-from src.core.exceptions import InternalServerException
+from src.core.exceptions import InternalServerException, ConflictException
 from sqlmodel import Session, select, func
+from sqlalchemy.exc import IntegrityError
 
 logger = logging.getLogger(__name__)
 
@@ -49,3 +51,34 @@ class InstitutionService:
         except Exception as e:
             logger.error(f"Error fetching Institutions: {e}")
             raise InternalServerException("Failed to fetch Institutions from database.") from e
+    
+    # API
+    def create_institutions(
+        self,
+        *,
+        request):
+        try:
+            unique_id = uuid4()
+
+            # insitution object to store in the DB
+            institution = Institution(
+                id=unique_id,
+                name=request.name
+            )
+
+            self.session.add(institution) 
+            self.session.commit()
+            self.session.refresh(institution)
+
+            final_response = InstitutionResponse.model_validate(institution)
+            return final_response
+
+        except IntegrityError as e:
+            self.session.rollback()
+            logger.error(f"Error creating institution: {e}")
+            raise ConflictException("Duplicate values violates unique constraint") from e
+
+        except Exception as e:
+            self.session.rollback()
+            logger.error(f"Error creating institution: {e}")
+            raise InternalServerException("Failed to create Institution") from e

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 from src.utils import http_client
 from src.models import Sender
 from src.models.response_models import SenderResponse
-from src.models.request_models import SenderRequest
+from src.models.request_models import SenderRequest, InstitutionRequest
 from src.services import SenderService
 
 
@@ -192,6 +192,20 @@ def make_template_request():
         request.file = mock_upload
         return request
 
+    return _factory
+
+# institutions fixures
+@pytest.fixture
+def make_institution_request():
+    """Returns a factory for mock InstitutionRequest instance"""
+
+    def _factory(
+        name: str = "Test Institution"
+    ) -> MagicMock:
+        request = MagicMock(spec=InstitutionRequest)
+        request.name = name 
+        return request
+    
     return _factory
 
 @pytest.fixture

--- a/tool/backend/test/test_institution_service.py
+++ b/tool/backend/test/test_institution_service.py
@@ -3,9 +3,10 @@ import pytest
 from sqlalchemy.exc import OperationalError
 from src.services.institution_service import InstitutionService
 from src.models.response_models import InstitutionListResponse
-from src.core.exceptions import InternalServerException
+from src.core.exceptions import InternalServerException, ConflictException
 from sqlmodel import SQLModel, Session, create_engine
 
+# get institutions list tests
 def test_get_institutions_default(institution_db):
     """Test fetching institutions with default pagination (page 1, size 10)."""
     service = InstitutionService(session=institution_db)
@@ -60,4 +61,52 @@ def test_get_institutions_db_error(monkeypatch, institution_db):
         service.get_institutions()
     
     assert "Failed to fetch Institutions from database" in str(excinfo.value)
+
+# create institutions test
+def test_create_institutions_success(institution_db, make_institution_request):
+    """Create institution success"""
+
+    service = InstitutionService(session=institution_db)
+
+    request = make_institution_request(name="Test Institution")
+
+    result = service.create_institutions(request=request)
+
+    assert result.name == "Test Institution"
+
+def test_create_institutions_internal_server_error(monkeypatch, institution_db, make_institution_request):
+    """Test Internal Server Error exception raising when exception happen"""
+
+    service = InstitutionService(session=institution_db)
+
+    request = make_institution_request(name="Test Institution")
+
+    def mock_commit(*args, **kwargs):
+        raise OperationalError("Fake DB error", None, None)
+
+    monkeypatch.setattr(institution_db, "commit", mock_commit)
+
+    with pytest.raises(InternalServerException) as excinfo:
+        service.create_institutions(request=request)
+
+    assert "Failed to create Institution" in str(excinfo.value)    
+
+def test_create_institutions_conflict_error(institution_db, make_institution_request):
+    """Test raise Conflict Exception when the db try to create duplicate record with the same name"""
+
+    service = InstitutionService(session=institution_db)
+
+    request_1 = make_institution_request(name="Test Institution")
+    request_2 = make_institution_request(name="Test Institution")
+
+    # first service call
+    result_1 = service.create_institutions(request=request_1)
+
+    assert result_1.name == "Test Institution"
+
+    # second service call with the same institution name
+    with pytest.raises(ConflictException) as excinfo:
+        service.create_institutions(request=request_2)
+
+    assert "Duplicate values violates unique constraint" in str(excinfo.value)
 

--- a/tool/backend/test/test_institution_service.py
+++ b/tool/backend/test/test_institution_service.py
@@ -1,8 +1,10 @@
 # tests/test_institution_service.py
+from pydantic import ValidationError
 import pytest
 from sqlalchemy.exc import OperationalError
 from src.services.institution_service import InstitutionService
 from src.models.response_models import InstitutionListResponse
+from src.models.request_models import InstitutionRequest
 from src.core.exceptions import InternalServerException, ConflictException
 from sqlmodel import SQLModel, Session, create_engine
 
@@ -109,4 +111,15 @@ def test_create_institutions_conflict_error(institution_db, make_institution_req
         service.create_institutions(request=request_2)
 
     assert "Duplicate values violates unique constraint" in str(excinfo.value)
+
+def test_create_institutions_with_empty_name(institution_db):
+    """Test raise Validation Error when pass an empty name"""
+
+    service = InstitutionService(session=institution_db)
+
+    with pytest.raises(ValidationError) as excinfo:
+        request = InstitutionRequest(name="")
+        service.create_institutions(request=request)
+
+    assert "String should have at least 1 character" in str(excinfo.value)
 

--- a/tool/backend/test/test_institution_service.py
+++ b/tool/backend/test/test_institution_service.py
@@ -111,7 +111,7 @@ def test_create_institutions_conflict_error(institution_db, make_institution_req
     with pytest.raises(ConflictException) as excinfo:
         service.create_institution(request=request_2)
 
-    assert "Institution with this name already exists." in str(excinfo.value)
+    assert "Institution with this name already exists" in str(excinfo.value)
 
 def test_create_institutions_with_empty_name(institution_db):
     """Test raise Validation Error when pass an empty name"""
@@ -175,7 +175,7 @@ def test_get_institution_internal_server_error(monkeypatch, institution_db):
     with pytest.raises(InternalServerException) as excinfo:
         service.get_institution(institution_id=random_id)
         
-    assert "Failed to read Insitution" in str(excinfo.value)
+    assert "Failed to read Institution" in str(excinfo.value)
 
 # update institution test
 def test_update_institution_success(institution_db, make_institution_request):
@@ -234,7 +234,7 @@ def test_update_institution_conflict_error(institution_db, make_institution_requ
     with pytest.raises(ConflictException) as excinfo:
         service.update_institution(institution_id=inst2.id, request=update_request)
         
-    assert "Institution with this name already exists." in str(excinfo.value)
+    assert "Institution with this name already exists" in str(excinfo.value)
 
 def test_update_institution_internal_server_error(monkeypatch, institution_db, make_institution_request):
     """Test update institution raises internal server error"""

--- a/tool/backend/test/test_institution_service.py
+++ b/tool/backend/test/test_institution_service.py
@@ -1,12 +1,13 @@
 # tests/test_institution_service.py
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 from sqlalchemy.exc import OperationalError
 from src.services.institution_service import InstitutionService
 from src.models.response_models import InstitutionListResponse
 from src.models.request_models import InstitutionRequest
-from src.core.exceptions import InternalServerException, ConflictException
+from src.core.exceptions import InternalServerException, ConflictException, BadRequestException, NotFoundException
 from sqlmodel import SQLModel, Session, create_engine
+from uuid import uuid4
 
 # get institutions list tests
 def test_get_institutions_default(institution_db):
@@ -122,4 +123,57 @@ def test_create_institutions_with_empty_name(institution_db):
         service.create_institutions(request=request)
 
     assert "String should have at least 1 character" in str(excinfo.value)
+
+# get institution by id test
+def test_get_institution_by_id_success(institution_db, make_institution_request):
+    """Get Institution by ID success"""
+    service = InstitutionService(session=institution_db)
+    request = make_institution_request(name="Test Institution")
+
+    # create institution
+    create_result = service.create_institutions(request=request)
+
+    # get institution
+    read_result = service.get_institution_by_id(institution_id=create_result.id)
+
+    assert read_result.name == create_result.name
+    assert read_result.id == create_result.id
+    assert read_result.created_at == create_result.created_at
+    assert read_result.updated_at == create_result.updated_at
+
+def test_get_institution_invalid_id(institution_db):
+    """Test read institution by invalid id"""
+
+    service = InstitutionService(session=institution_db)
+
+    with pytest.raises(BadRequestException) as exeinfo:
+        service.get_institution_by_id(institution_id="")
+    
+    assert "Invalid UUID format" in str(exeinfo.value)
+
+def test_get_institution_not_found(institution_db):
+    """Test get institution not found"""
+    service = InstitutionService(session=institution_db)
+    random_id = str(uuid4())
+
+    with pytest.raises(NotFoundException) as excinfo:
+        service.get_institution_by_id(institution_id=random_id)
+        
+    assert f"Institution with id {random_id} not found." in str(excinfo.value)
+
+def test_get_institution_internal_server_error(monkeypatch, institution_db):
+    """Test get institution raises internal server error"""
+    service = InstitutionService(session=institution_db)
+    
+    def mock_get(*args, **kwargs):
+        raise OperationalError("Fake DB error", None, None)
+        
+    monkeypatch.setattr(institution_db, "get", mock_get)
+    
+    random_id = str(uuid4())
+    
+    with pytest.raises(InternalServerException) as excinfo:
+        service.get_institution_by_id(institution_id=random_id)
+        
+    assert "Failed to read Insitution" in str(excinfo.value)
 

--- a/tool/backend/test/test_institution_service.py
+++ b/tool/backend/test/test_institution_service.py
@@ -177,3 +177,82 @@ def test_get_institution_internal_server_error(monkeypatch, institution_db):
         
     assert "Failed to read Insitution" in str(excinfo.value)
 
+# update institution test
+def test_update_institution_success(institution_db, make_institution_request):
+    """Test update institution success"""
+    service = InstitutionService(session=institution_db)
+    
+    # Create an institution first
+    create_request = make_institution_request(name="Old Name")
+    created_institution = service.create_institutions(request=create_request)
+    
+    # Update the institution
+    update_request = make_institution_request(name="New Name")
+    updated_institution = service.update_institution(
+        institution_id=created_institution.id, 
+        request=update_request
+    )
+    
+    assert updated_institution.id == created_institution.id
+    assert updated_institution.name == "New Name"
+
+def test_update_institution_invalid_id(institution_db, make_institution_request):
+    """Test update institution with invalid id"""
+    service = InstitutionService(session=institution_db)
+    request = make_institution_request(name="New Name")
+    
+    with pytest.raises(BadRequestException) as excinfo:
+        service.update_institution(institution_id="invalid-uuid", request=request)
+        
+    assert "Invalid UUID format" in str(excinfo.value)
+
+def test_update_institution_not_found(institution_db, make_institution_request):
+    """Test update institution not found"""
+    service = InstitutionService(session=institution_db)
+    random_id = str(uuid4())
+    request = make_institution_request(name="New Name")
+    
+    with pytest.raises(NotFoundException) as excinfo:
+        service.update_institution(institution_id=random_id, request=request)
+        
+    assert f"Institution with id {random_id} not found." in str(excinfo.value)
+
+def test_update_institution_conflict_error(institution_db, make_institution_request):
+    """Test update institution conflict error (duplicate name)"""
+    service = InstitutionService(session=institution_db)
+    
+    # Create two institutions
+    req1 = make_institution_request(name="Institution A")
+    service.create_institutions(request=req1)
+    
+    req2 = make_institution_request(name="Institution B")
+    inst2 = service.create_institutions(request=req2)
+    
+    # Try to update inst2's name to "Institution A"
+    update_request = make_institution_request(name="Institution A")
+    
+    with pytest.raises(ConflictException) as excinfo:
+        service.update_institution(institution_id=inst2.id, request=update_request)
+        
+    assert "Institution with this name already exists." in str(excinfo.value)
+
+def test_update_institution_internal_server_error(monkeypatch, institution_db, make_institution_request):
+    """Test update institution raises internal server error"""
+    service = InstitutionService(session=institution_db)
+    
+    # Create an institution first
+    create_request = make_institution_request(name="Old Name")
+    created_institution = service.create_institutions(request=create_request)
+    
+    update_request = make_institution_request(name="New Name")
+    
+    # Mock commit to raise OperationalError
+    def mock_commit(*args, **kwargs):
+        raise OperationalError("Fake DB error", None, None)
+        
+    monkeypatch.setattr(institution_db, "commit", mock_commit)
+    
+    with pytest.raises(InternalServerException) as excinfo:
+        service.update_institution(institution_id=created_institution.id, request=update_request)
+        
+    assert "Failed to update Institution" in str(excinfo.value)

--- a/tool/backend/test/test_institution_service.py
+++ b/tool/backend/test/test_institution_service.py
@@ -1,7 +1,7 @@
 # tests/test_institution_service.py
 import pytest
 from pydantic import ValidationError
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, IntegrityError
 from src.services.institution_service import InstitutionService
 from src.models.response_models import InstitutionListResponse
 from src.models.request_models import InstitutionRequest
@@ -73,7 +73,7 @@ def test_create_institutions_success(institution_db, make_institution_request):
 
     request = make_institution_request(name="Test Institution")
 
-    result = service.create_institutions(request=request)
+    result = service.create_institution(request=request)
 
     assert result.name == "Test Institution"
 
@@ -90,7 +90,7 @@ def test_create_institutions_internal_server_error(monkeypatch, institution_db, 
     monkeypatch.setattr(institution_db, "commit", mock_commit)
 
     with pytest.raises(InternalServerException) as excinfo:
-        service.create_institutions(request=request)
+        service.create_institution(request=request)
 
     assert "Failed to create Institution" in str(excinfo.value)    
 
@@ -103,15 +103,15 @@ def test_create_institutions_conflict_error(institution_db, make_institution_req
     request_2 = make_institution_request(name="Test Institution")
 
     # first service call
-    result_1 = service.create_institutions(request=request_1)
+    result_1 = service.create_institution(request=request_1)
 
     assert result_1.name == "Test Institution"
 
     # second service call with the same institution name
     with pytest.raises(ConflictException) as excinfo:
-        service.create_institutions(request=request_2)
+        service.create_institution(request=request_2)
 
-    assert "Duplicate values violates unique constraint" in str(excinfo.value)
+    assert "Institution with this name already exists." in str(excinfo.value)
 
 def test_create_institutions_with_empty_name(institution_db):
     """Test raise Validation Error when pass an empty name"""
@@ -120,7 +120,7 @@ def test_create_institutions_with_empty_name(institution_db):
 
     with pytest.raises(ValidationError) as excinfo:
         request = InstitutionRequest(name="")
-        service.create_institutions(request=request)
+        service.create_institution(request=request)
 
     assert "String should have at least 1 character" in str(excinfo.value)
 
@@ -131,10 +131,10 @@ def test_get_institution_by_id_success(institution_db, make_institution_request)
     request = make_institution_request(name="Test Institution")
 
     # create institution
-    create_result = service.create_institutions(request=request)
+    create_result = service.create_institution(request=request)
 
     # get institution
-    read_result = service.get_institution_by_id(institution_id=create_result.id)
+    read_result = service.get_institution(institution_id=create_result.id)
 
     assert read_result.name == create_result.name
     assert read_result.id == create_result.id
@@ -147,7 +147,7 @@ def test_get_institution_invalid_id(institution_db):
     service = InstitutionService(session=institution_db)
 
     with pytest.raises(BadRequestException) as exeinfo:
-        service.get_institution_by_id(institution_id="")
+        service.get_institution(institution_id="")
     
     assert "Invalid UUID format" in str(exeinfo.value)
 
@@ -157,7 +157,7 @@ def test_get_institution_not_found(institution_db):
     random_id = str(uuid4())
 
     with pytest.raises(NotFoundException) as excinfo:
-        service.get_institution_by_id(institution_id=random_id)
+        service.get_institution(institution_id=random_id)
         
     assert f"Institution with id {random_id} not found." in str(excinfo.value)
 
@@ -173,7 +173,7 @@ def test_get_institution_internal_server_error(monkeypatch, institution_db):
     random_id = str(uuid4())
     
     with pytest.raises(InternalServerException) as excinfo:
-        service.get_institution_by_id(institution_id=random_id)
+        service.get_institution(institution_id=random_id)
         
     assert "Failed to read Insitution" in str(excinfo.value)
 
@@ -184,7 +184,7 @@ def test_update_institution_success(institution_db, make_institution_request):
     
     # Create an institution first
     create_request = make_institution_request(name="Old Name")
-    created_institution = service.create_institutions(request=create_request)
+    created_institution = service.create_institution(request=create_request)
     
     # Update the institution
     update_request = make_institution_request(name="New Name")
@@ -223,10 +223,10 @@ def test_update_institution_conflict_error(institution_db, make_institution_requ
     
     # Create two institutions
     req1 = make_institution_request(name="Institution A")
-    service.create_institutions(request=req1)
+    service.create_institution(request=req1)
     
     req2 = make_institution_request(name="Institution B")
-    inst2 = service.create_institutions(request=req2)
+    inst2 = service.create_institution(request=req2)
     
     # Try to update inst2's name to "Institution A"
     update_request = make_institution_request(name="Institution A")
@@ -242,7 +242,7 @@ def test_update_institution_internal_server_error(monkeypatch, institution_db, m
     
     # Create an institution first
     create_request = make_institution_request(name="Old Name")
-    created_institution = service.create_institutions(request=create_request)
+    created_institution = service.create_institution(request=create_request)
     
     update_request = make_institution_request(name="New Name")
     
@@ -256,3 +256,77 @@ def test_update_institution_internal_server_error(monkeypatch, institution_db, m
         service.update_institution(institution_id=created_institution.id, request=update_request)
         
     assert "Failed to update Institution" in str(excinfo.value)
+
+# delete institution test
+def test_delete_institution_success(institution_db, make_institution_request):
+    """Test delete institution success"""
+    service = InstitutionService(session=institution_db)
+    
+    # Create an institution first
+    create_request = make_institution_request(name="To Be Deleted")
+    created_institution = service.create_institution(request=create_request)
+    
+    # Delete the institution
+    result = service.delete_institution(institution_id=created_institution.id)
+    assert result is None
+    
+    # Verify it's gone
+    with pytest.raises(NotFoundException):
+        service.get_institution(institution_id=created_institution.id)
+
+def test_delete_institution_invalid_id(institution_db):
+    """Test delete institution with invalid id"""
+    service = InstitutionService(session=institution_db)
+    
+    with pytest.raises(BadRequestException) as excinfo:
+        service.delete_institution(institution_id="invalid-uuid")
+        
+    assert "Invalid UUID format" in str(excinfo.value)
+
+def test_delete_institution_not_found(institution_db):
+    """Test delete institution not found"""
+    service = InstitutionService(session=institution_db)
+    random_id = str(uuid4())
+    
+    with pytest.raises(NotFoundException) as excinfo:
+        service.delete_institution(institution_id=random_id)
+        
+    assert f"Institution with id {random_id} not found." in str(excinfo.value)
+
+def test_delete_institution_conflict_error(monkeypatch, institution_db, make_institution_request):
+    """Test delete institution conflict error (IntegrityError)"""
+    service = InstitutionService(session=institution_db)
+    
+    # Create an institution first
+    create_request = make_institution_request(name="To Be Deleted")
+    created_institution = service.create_institution(request=create_request)
+    
+    # Mock delete to raise IntegrityError (simulating foreign key constraint violation)
+    def mock_delete(*args, **kwargs):
+        raise IntegrityError("Fake Integrity error", None, None)
+        
+    monkeypatch.setattr(institution_db, "delete", mock_delete)
+    
+    with pytest.raises(ConflictException) as excinfo:
+        service.delete_institution(institution_id=created_institution.id)
+        
+    assert "Cannot delete Institution because it is used in existing records." in str(excinfo.value)
+
+def test_delete_institution_internal_server_error(monkeypatch, institution_db, make_institution_request):
+    """Test delete institution raises internal server error"""
+    service = InstitutionService(session=institution_db)
+    
+    # Create an institution first
+    create_request = make_institution_request(name="To Be Deleted")
+    created_institution = service.create_institution(request=create_request)
+    
+    # Mock commit to raise OperationalError
+    def mock_commit(*args, **kwargs):
+        raise OperationalError("Fake DB error", None, None)
+        
+    monkeypatch.setattr(institution_db, "commit", mock_commit)
+    
+    with pytest.raises(InternalServerException) as excinfo:
+        service.delete_institution(institution_id=created_institution.id)
+        
+    assert "Failed to delete Institution" in str(excinfo.value)


### PR DESCRIPTION
## Overview
This PR introduces four new API endpoints that enables **Institutions** create, update, deletion and read by ID. 

**New API endpoint:**
`POST /institutions`
`PUT /institutions/{id}`
`GET /institutions/{id}`
`DELETE /institutions/{id}`

---

## Changes
* **Routing:** Added new routers to the `institution_router.py` file.
* **Service Layer:** Developed the services in the `institution_service.py` file.
* **Testing:** Added new test cases to cover the service functionalities.

---

## Testing
* **Service Tests:** Updated `test_institution_service.py` with new test cases to cover the new endpoint.
* **Mocks:** Updated `conftest.py` with new mock services.
* **Status:** All tests are passing.

---

## Additional Information
This PR Closes #39
Closes #41 
Closes #42 
Closes #66 