### PR TITLE
GH-60 : [RTI][TOOL][BACKEND] Fail fast on database connection timeout at startup

### DIFF
--- a/tool/backend/.env.example
+++ b/tool/backend/.env.example
@@ -8,6 +8,10 @@ POSTGRES_USER=rti
 POSTGRES_PASSWORD=rti
 POSTGRES_DB=rti
 
+# db bounded-retry
+MAX_RETRIES=5
+RETRY_DELAY=3  #in seconds
+
 # asgardio secrets
 ASGARDEO_ORG=<org_name>
 CLIENT_ID=<client_id>

--- a/tool/backend/main.py
+++ b/tool/backend/main.py
@@ -1,54 +1,50 @@
-import logging
-from src.utils.http_client import http_client
-from src.routers import rti_template_router, institution_router, position_router, sender_router, receiver_router, rti_request_router, rti_status_router
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from contextlib import asynccontextmanager
-from src.core.exceptions import BaseAPIException, api_exception_handler, validation_exception_handler
-from src.core.configs import settings
-from fastapi.exceptions import RequestValidationError
-
-from sqlalchemy import text
-from src.repositories.db import engine
 import asyncio
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+
+from src.core.configs import settings
+from src.core.exceptions import (
+    BaseAPIException,
+    api_exception_handler,
+    validation_exception_handler,
+)
+from src.routers import (
+    institution_router,
+    position_router,
+    rti_template_router,
+    rti_request_router,
+    rti_status_router,
+    sender_router,
+    receiver_router
+)
+
+from src.utils.http_client import http_client
+from src.utils.lifespan_helpers import (
+    ping_db,
+    safe_close_http_client,
+    safe_dispose_engine,
+)
 
 # Configure logging to show INFO level messages
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# db retrying settings 
+# db retrying settings
 MAX_RETRIES = settings.MAX_RETRIES
-RETRY_DELAY = settings.RETRY_DELAY  #seconds
+RETRY_DELAY = settings.RETRY_DELAY  # seconds
 
-# Helper Functions
-# synchronous(blocking) db ping helper
-def ping_db():
-    with engine.connect() as conn:
-        conn.execute(text("SELECT 1"))
 
-def _safe_dispose_engine():
-    """Attempts to dispose the DB engine, logs full trace on failure."""
-    try:
-        engine.dispose()
-    except Exception:
-        logger.exception("Teardown Error: Failed to cleanly dispose DB engine")
-
-async def _safe_close_http_client():
-    """Attempts to close HTTP client, logs full trace on failure."""
-    try:
-        await http_client.close()
-    except Exception:
-        logger.exception("Teardown Error: Failed to close HTTP client")
-
-    
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("Lifespan connection starting...")
     http_client_started = False
-    
+
     # DB connectivity check
     try:
-        
         for attempt in range(1, MAX_RETRIES + 1):
             try:
                 # run in threadpool to avoid blocking
@@ -56,52 +52,53 @@ async def lifespan(app: FastAPI):
                 logger.info("Database connection successful!")
                 # exit retry loop and continue startup on success
                 break
-            
+
             except Exception as e:
-                
                 if attempt == MAX_RETRIES:
-                    logger.critical("All DB connection attempts failed. Exiting.", exc_info=True)
-                    # Copilot: Exception chaining (from e) preserves original stack trace
-                    raise RuntimeError("Cannot connect to database. Aborting startup.") from e
+                    logger.critical(
+                        "All DB connection attempts failed. Exiting.", exc_info=True
+                    )
+                    #Exception chaining (from e) preserves original stack trace
+                    raise RuntimeError(
+                        "Cannot connect to database. Aborting startup."
+                    ) from e
                 else:
-                    logger.warning( "DB connection attempt %s/%s failed",
-                                attempt,
-                                MAX_RETRIES,
-                                exc_info=True
-                            )
-                    
+                    logger.warning(
+                        "DB connection attempt %s/%s failed: %s",
+                        attempt,
+                        MAX_RETRIES,
+                        str(e),
+                        exc_info=True,
+                    )
                 # delay for the next poll
                 await asyncio.sleep(RETRY_DELAY)
-        
-    # http client startup check  
+        # http client startup check
         try:
             await http_client.start()
-            http_client_started=True
-        except Exception :
-            logger.exception( "http client failed to start ")
-            raise 
-            
-            
+            http_client_started = True
+        except Exception:
+            logger.exception("http client failed to start")
+            raise
         yield
-        
+
     finally:
         if http_client_started:
-            await _safe_close_http_client()
-        
-        _safe_dispose_engine()
-        
-        
+            await safe_close_http_client()
+        safe_dispose_engine()
         logger.info("Lifespan connection ending...")
+
 
 app = FastAPI(
     title="RTI Tracker",
     description="A FastAPI backend for RTI tracker",
     version="1.0.0",
-    lifespan=lifespan
+    lifespan=lifespan,
 )
 
 # check for allowed origins
-allowed_origins = [origin.strip() for origin in settings.ALLOWED_ORIGINS.split(",") if origin.strip()]
+allowed_origins = [
+    origin.strip() for origin in settings.ALLOWED_ORIGINS.split(",") if origin.strip()
+]
 if not allowed_origins:
     raise ValueError("ALLOWED_ORIGINS is not configured")
 
@@ -113,10 +110,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 # health check
 @app.get("/health", tags=["Service"])
 def health_check():
     return {"status": "Healthy Service"}
+
 
 app.include_router(rti_template_router)
 app.include_router(institution_router)
@@ -128,4 +127,3 @@ app.include_router(rti_status_router)
 
 app.add_exception_handler(BaseAPIException, api_exception_handler)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)
-

--- a/tool/backend/main.py
+++ b/tool/backend/main.py
@@ -20,39 +20,78 @@ logger = logging.getLogger(__name__)
 MAX_RETRIES = settings.MAX_RETRIES
 RETRY_DELAY = settings.RETRY_DELAY  #seconds
 
+# Helper Functions
 # synchronous(blocking) db ping helper
 def ping_db():
     with engine.connect() as conn:
         conn.execute(text("SELECT 1"))
 
+def _safe_dispose_engine():
+    """Attempts to dispose the DB engine, logs full trace on failure."""
+    try:
+        engine.dispose()
+    except Exception:
+        logger.exception("Teardown Error: Failed to cleanly dispose DB engine")
+
+async def _safe_close_http_client():
+    """Attempts to close HTTP client, logs full trace on failure."""
+    try:
+        await http_client.close()
+    except Exception:
+        logger.exception("Teardown Error: Failed to close HTTP client")
+
+    
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("Lifespan connection starting...")
+    http_client_started = False
     
-    # bounded-retry loop for pinging the db
-    for attempt in range(1, MAX_RETRIES + 1):
+    # DB connectivity check
+    try:
+        
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                # run in threadpool to avoid blocking
+                await asyncio.to_thread(ping_db)
+                logger.info("Database connection successful!")
+                # exit retry loop and continue startup on success
+                break
+            
+            except Exception as e:
+                
+                if attempt == MAX_RETRIES:
+                    logger.critical("All DB connection attempts failed. Exiting.", exc_info=True)
+                    # Copilot: Exception chaining (from e) preserves original stack trace
+                    raise RuntimeError("Cannot connect to database. Aborting startup.") from e
+                else:
+                    logger.warning( "DB connection attempt %s/%s failed",
+                                attempt,
+                                MAX_RETRIES,
+                                exc_info=True
+                            )
+                    
+                # delay for the next poll
+                await asyncio.sleep(RETRY_DELAY)
+        
+    # http client startup check  
         try:
-            # run in threadpool to avoid blocking 
-            await asyncio.to_thread(ping_db)
-            logger.info("Database connection successful!")
-            # exit retry loop and continue startup on success
-            break
-        except Exception as e:
-            logger.warning(f"DB connection attempt {attempt}/{MAX_RETRIES} failed: {e}")
-
-            if attempt == MAX_RETRIES:
-                logger.critical("All DB connection attempts failed. Exiting.",exc_info=True)
-                raise RuntimeError("Cannot connect to database. Aborting startup.")
-            # delay for the next poll
-            await asyncio.sleep(RETRY_DELAY)
-    
-    await http_client.start()
-    
-    yield
-    engine.dispose()
-    
-    await http_client.close()
-    logger.info("Lifespan connection ending...")
+            await http_client.start()
+            http_client_started=True
+        except Exception :
+            logger.exception( "http client failed to start ")
+            raise 
+            
+            
+        yield
+        
+    finally:
+        if http_client_started:
+            await _safe_close_http_client()
+        
+        _safe_dispose_engine()
+        
+        
+        logger.info("Lifespan connection ending...")
 
 app = FastAPI(
     title="RTI Tracker",

--- a/tool/backend/main.py
+++ b/tool/backend/main.py
@@ -8,16 +8,49 @@ from src.core.exceptions import BaseAPIException, api_exception_handler, validat
 from src.core.configs import settings
 from fastapi.exceptions import RequestValidationError
 
+from sqlalchemy import text
+from src.repositories.db import engine
+import asyncio
 
 # Configure logging to show INFO level messages
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# db retrying settings 
+MAX_RETRIES = settings.MAX_RETRIES
+RETRY_DELAY = settings.RETRY_DELAY  #seconds
+
+# synchronous(blocking) db ping helper
+def ping_db():
+    with engine.connect() as conn:
+        conn.execute(text("SELECT 1"))
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("Lifespan connection starting...")
+    
+    # bounded-retry loop for pinging the db
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            # run in threadpool to avoid blocking 
+            await asyncio.to_thread(ping_db)
+            logger.info("Database connection successful!")
+            # exit retry loop and continue startup on success
+            break
+        except Exception as e:
+            logger.warning(f"DB connection attempt {attempt}/{MAX_RETRIES} failed: {e}")
+
+            if attempt == MAX_RETRIES:
+                logger.critical("All DB connection attempts failed. Exiting.",exc_info=True)
+                raise RuntimeError("Cannot connect to database. Aborting startup.")
+            # delay for the next poll
+            await asyncio.sleep(RETRY_DELAY)
+    
     await http_client.start()
+    
     yield
+    engine.dispose()
+    
     await http_client.close()
     logger.info("Lifespan connection ending...")
 

--- a/tool/backend/src/core/configs.py
+++ b/tool/backend/src/core/configs.py
@@ -10,6 +10,10 @@ class Settings(BaseSettings):
     POSTGRES_USER: str
     POSTGRES_PASSWORD: str
     POSTGRES_DB: str
+    
+    # database bounded-retry
+    MAX_RETRIES:int=5
+    RETRY_DELAY:int=3  #in seconds
 
     # asgardio configuration
     ASGARDEO_ORG: str

--- a/tool/backend/src/core/configs.py
+++ b/tool/backend/src/core/configs.py
@@ -1,8 +1,9 @@
 from pydantic_settings import SettingsConfigDict, BaseSettings
 from pydantic import Field
 
+
 class Settings(BaseSettings):
-    
+
     # allowed origins
     ALLOWED_ORIGINS: str
 
@@ -11,10 +12,10 @@ class Settings(BaseSettings):
     POSTGRES_USER: str
     POSTGRES_PASSWORD: str
     POSTGRES_DB: str
-    
+
     # database bounded-retry
-    MAX_RETRIES: int = Field(default=5, ge=1) # must >=1 second
-    RETRY_DELAY: int = Field(default=3, ge=0)  # must >= 0 second
+    MAX_RETRIES: int = Field(default=5, ge=1)  # must attempt at least once >=1
+    RETRY_DELAY: int = Field(default=3, ge=0)  # seconds to wait between retry attempts (0 = no delay).
 
     # asgardio configuration
     ASGARDEO_ORG: str
@@ -27,7 +28,7 @@ class Settings(BaseSettings):
     GITHUB_BRANCH: str
 
     # http client configuration
-    HTTP_POOL_SIZE: int = 50 
+    HTTP_POOL_SIZE: int = 50
     HTTP_POOL_SIZE_PER_HOST: int = 40
     HTTP_TTL_DNS_CACHE: int = 300
     HTTP_TIMEOUT_TOTAL: int = 90
@@ -39,5 +40,5 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
-settings = Settings()
 
+settings = Settings()

--- a/tool/backend/src/core/configs.py
+++ b/tool/backend/src/core/configs.py
@@ -1,4 +1,5 @@
 from pydantic_settings import SettingsConfigDict, BaseSettings
+from pydantic import Field
 
 class Settings(BaseSettings):
     
@@ -12,8 +13,8 @@ class Settings(BaseSettings):
     POSTGRES_DB: str
     
     # database bounded-retry
-    MAX_RETRIES:int=5
-    RETRY_DELAY:int=3  #in seconds
+    MAX_RETRIES: int = Field(default=5, ge=1) # must >=1 second
+    RETRY_DELAY: int = Field(default=3, ge=0)  # must >= 0 second
 
     # asgardio configuration
     ASGARDEO_ORG: str

--- a/tool/backend/src/utils/lifespan_helpers.py
+++ b/tool/backend/src/utils/lifespan_helpers.py
@@ -1,0 +1,28 @@
+import logging
+from sqlalchemy import text
+from src.repositories.db import engine
+from src.utils.http_client import http_client
+
+logger = logging.getLogger(__name__)
+
+
+def ping_db():
+    """Synchronous (blocking) db ping helper."""
+    with engine.connect() as conn:
+        conn.execute(text("SELECT 1"))
+
+
+def safe_dispose_engine():
+    """Attempts to dispose the DB engine, logs full trace on failure."""
+    try:
+        engine.dispose()
+    except Exception:
+        logger.exception("Teardown Error: Failed to cleanly dispose DB engine")
+
+
+async def safe_close_http_client():
+    """Attempts to close HTTP client, logs full trace on failure."""
+    try:
+        await http_client.close()
+    except Exception:
+        logger.exception("Teardown Error: Failed to close HTTP client")

--- a/tool/backend/test/test_startup_db_lifespan.py
+++ b/tool/backend/test/test_startup_db_lifespan.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-
 REQUIRED_ENV = {
     "ALLOWED_ORIGINS": "http://localhost:5173",
     "POSTGRES_HOST": "localhost:5432",
@@ -24,12 +23,17 @@ def load_main_module(monkeypatch):
     for key, value in REQUIRED_ENV.items():
         monkeypatch.setenv(key, value)
 
-    # clear config + main so settings reload cleanly
-    if "src.core.configs" in sys.modules:
-        del sys.modules["src.core.configs"]
+    import_chain = [
+        "src.core.configs",
+        "src.core",
+        "main",
+        "src.utils.lifespan_helpers",
+    ]
 
-    if "main" in sys.modules:
-        del sys.modules["main"]
+    # clear the full import chain so settings reloads with fresh env vars
+    for module_name in import_chain:
+        if module_name in sys.modules:
+            del sys.modules[module_name]
 
     return importlib.import_module("main")
 
@@ -41,16 +45,16 @@ async def test_lifespan_starts_when_db_ping_succeeds(monkeypatch):
     ping_mock = MagicMock(return_value=None)
     to_thread_mock = AsyncMock(side_effect=lambda fn: fn())
     start_mock = AsyncMock()
-    close_mock = AsyncMock()
-    dispose_mock = MagicMock()
+    safe_close_mock = AsyncMock()
+    safe_dispose_mock = MagicMock()
     sleep_mock = AsyncMock()
 
     monkeypatch.setattr(main, "MAX_RETRIES", 3)
     monkeypatch.setattr(main.asyncio, "to_thread", to_thread_mock)
     monkeypatch.setattr(main, "ping_db", ping_mock)
     monkeypatch.setattr(main.http_client, "start", start_mock)
-    monkeypatch.setattr(main.http_client, "close", close_mock)
-    monkeypatch.setattr(main.engine, "dispose", dispose_mock)
+    monkeypatch.setattr(main, "safe_close_http_client", safe_close_mock)
+    monkeypatch.setattr(main, "safe_dispose_engine", safe_dispose_mock)
     monkeypatch.setattr(main.asyncio, "sleep", sleep_mock)
 
     async with main.lifespan(main.app):
@@ -58,8 +62,8 @@ async def test_lifespan_starts_when_db_ping_succeeds(monkeypatch):
 
     assert ping_mock.call_count == 1
     start_mock.assert_awaited_once()
-    close_mock.assert_awaited_once()
-    dispose_mock.assert_called_once()
+    safe_close_mock.assert_awaited_once()
+    safe_dispose_mock.assert_called_once()
     sleep_mock.assert_not_awaited()
 
 
@@ -70,8 +74,8 @@ async def test_lifespan_retries_then_succeeds(monkeypatch):
     ping_mock = MagicMock(side_effect=[Exception("db down"), None])
     to_thread_mock = AsyncMock(side_effect=lambda fn: fn())
     start_mock = AsyncMock()
-    close_mock = AsyncMock()
-    dispose_mock = MagicMock()
+    safe_close_mock = AsyncMock()
+    safe_dispose_mock = MagicMock()
     sleep_mock = AsyncMock()
 
     monkeypatch.setattr(main, "MAX_RETRIES", 3)
@@ -79,8 +83,8 @@ async def test_lifespan_retries_then_succeeds(monkeypatch):
     monkeypatch.setattr(main.asyncio, "to_thread", to_thread_mock)
     monkeypatch.setattr(main, "ping_db", ping_mock)
     monkeypatch.setattr(main.http_client, "start", start_mock)
-    monkeypatch.setattr(main.http_client, "close", close_mock)
-    monkeypatch.setattr(main.engine, "dispose", dispose_mock)
+    monkeypatch.setattr(main, "safe_close_http_client", safe_close_mock)
+    monkeypatch.setattr(main, "safe_dispose_engine", safe_dispose_mock)
     monkeypatch.setattr(main.asyncio, "sleep", sleep_mock)
 
     async with main.lifespan(main.app):
@@ -89,8 +93,8 @@ async def test_lifespan_retries_then_succeeds(monkeypatch):
     assert ping_mock.call_count == 2
     sleep_mock.assert_awaited_once_with(0)
     start_mock.assert_awaited_once()
-    close_mock.assert_awaited_once()
-    dispose_mock.assert_called_once()
+    safe_close_mock.assert_awaited_once()
+    safe_dispose_mock.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -100,8 +104,8 @@ async def test_lifespan_fails_fast_after_max_retries(monkeypatch):
     ping_mock = MagicMock(side_effect=Exception("db down"))
     to_thread_mock = AsyncMock(side_effect=lambda fn: fn())
     start_mock = AsyncMock()
-    close_mock = AsyncMock()
-    dispose_mock = MagicMock()
+    safe_close_mock = AsyncMock()
+    safe_dispose_mock = MagicMock()
     sleep_mock = AsyncMock()
 
     monkeypatch.setattr(main, "MAX_RETRIES", 3)
@@ -109,8 +113,8 @@ async def test_lifespan_fails_fast_after_max_retries(monkeypatch):
     monkeypatch.setattr(main.asyncio, "to_thread", to_thread_mock)
     monkeypatch.setattr(main, "ping_db", ping_mock)
     monkeypatch.setattr(main.http_client, "start", start_mock)
-    monkeypatch.setattr(main.http_client, "close", close_mock)
-    monkeypatch.setattr(main.engine, "dispose", dispose_mock)
+    monkeypatch.setattr(main, "safe_close_http_client", safe_close_mock)
+    monkeypatch.setattr(main, "safe_dispose_engine", safe_dispose_mock)
     monkeypatch.setattr(main.asyncio, "sleep", sleep_mock)
 
     with pytest.raises(RuntimeError, match="Cannot connect to database"):
@@ -122,9 +126,9 @@ async def test_lifespan_fails_fast_after_max_retries(monkeypatch):
     start_mock.assert_not_awaited()
 
     # http client never started → should NOT be closed
-    close_mock.assert_not_awaited()
+    safe_close_mock.assert_not_awaited()
 
-    dispose_mock.assert_called_once()
+    safe_dispose_mock.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -134,16 +138,16 @@ async def test_lifespan_fails_if_http_client_fails(monkeypatch):
     ping_mock = MagicMock(return_value=None)
     to_thread_mock = AsyncMock(side_effect=lambda fn: fn())
     start_mock = AsyncMock(side_effect=Exception("http client error"))
-    close_mock = AsyncMock()
-    dispose_mock = MagicMock()
+    safe_close_mock = AsyncMock()
+    safe_dispose_mock = MagicMock()
     sleep_mock = AsyncMock()
 
     monkeypatch.setattr(main, "MAX_RETRIES", 3)
     monkeypatch.setattr(main.asyncio, "to_thread", to_thread_mock)
     monkeypatch.setattr(main, "ping_db", ping_mock)
     monkeypatch.setattr(main.http_client, "start", start_mock)
-    monkeypatch.setattr(main.http_client, "close", close_mock)
-    monkeypatch.setattr(main.engine, "dispose", dispose_mock)
+    monkeypatch.setattr(main, "safe_close_http_client", safe_close_mock)
+    monkeypatch.setattr(main, "safe_dispose_engine", safe_dispose_mock)
     monkeypatch.setattr(main.asyncio, "sleep", sleep_mock)
 
     with pytest.raises(Exception, match="http client error"):
@@ -152,7 +156,7 @@ async def test_lifespan_fails_if_http_client_fails(monkeypatch):
 
     start_mock.assert_awaited_once()
 
-    # client never successfully started → should NOT be closed
-    close_mock.assert_not_awaited()
+    # http client never successfully started → should NOT be closed
+    safe_close_mock.assert_not_awaited()
 
-    dispose_mock.assert_called_once()
+    safe_dispose_mock.assert_called_once()

--- a/tool/backend/test/test_startup_db_lifespan.py
+++ b/tool/backend/test/test_startup_db_lifespan.py
@@ -24,6 +24,10 @@ def load_main_module(monkeypatch):
     for key, value in REQUIRED_ENV.items():
         monkeypatch.setenv(key, value)
 
+    # clear config + main so settings reload cleanly
+    if "src.core.configs" in sys.modules:
+        del sys.modules["src.core.configs"]
+
     if "main" in sys.modules:
         del sys.modules["main"]
 
@@ -35,12 +39,14 @@ async def test_lifespan_starts_when_db_ping_succeeds(monkeypatch):
     main = load_main_module(monkeypatch)
 
     ping_mock = MagicMock(return_value=None)
+    to_thread_mock = AsyncMock(side_effect=lambda fn: fn())
     start_mock = AsyncMock()
     close_mock = AsyncMock()
     dispose_mock = MagicMock()
     sleep_mock = AsyncMock()
 
     monkeypatch.setattr(main, "MAX_RETRIES", 3)
+    monkeypatch.setattr(main.asyncio, "to_thread", to_thread_mock)
     monkeypatch.setattr(main, "ping_db", ping_mock)
     monkeypatch.setattr(main.http_client, "start", start_mock)
     monkeypatch.setattr(main.http_client, "close", close_mock)
@@ -62,6 +68,7 @@ async def test_lifespan_retries_then_succeeds(monkeypatch):
     main = load_main_module(monkeypatch)
 
     ping_mock = MagicMock(side_effect=[Exception("db down"), None])
+    to_thread_mock = AsyncMock(side_effect=lambda fn: fn())
     start_mock = AsyncMock()
     close_mock = AsyncMock()
     dispose_mock = MagicMock()
@@ -69,6 +76,7 @@ async def test_lifespan_retries_then_succeeds(monkeypatch):
 
     monkeypatch.setattr(main, "MAX_RETRIES", 3)
     monkeypatch.setattr(main, "RETRY_DELAY", 0)
+    monkeypatch.setattr(main.asyncio, "to_thread", to_thread_mock)
     monkeypatch.setattr(main, "ping_db", ping_mock)
     monkeypatch.setattr(main.http_client, "start", start_mock)
     monkeypatch.setattr(main.http_client, "close", close_mock)
@@ -82,6 +90,7 @@ async def test_lifespan_retries_then_succeeds(monkeypatch):
     sleep_mock.assert_awaited_once_with(0)
     start_mock.assert_awaited_once()
     close_mock.assert_awaited_once()
+    dispose_mock.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -89,6 +98,7 @@ async def test_lifespan_fails_fast_after_max_retries(monkeypatch):
     main = load_main_module(monkeypatch)
 
     ping_mock = MagicMock(side_effect=Exception("db down"))
+    to_thread_mock = AsyncMock(side_effect=lambda fn: fn())
     start_mock = AsyncMock()
     close_mock = AsyncMock()
     dispose_mock = MagicMock()
@@ -96,6 +106,7 @@ async def test_lifespan_fails_fast_after_max_retries(monkeypatch):
 
     monkeypatch.setattr(main, "MAX_RETRIES", 3)
     monkeypatch.setattr(main, "RETRY_DELAY", 0)
+    monkeypatch.setattr(main.asyncio, "to_thread", to_thread_mock)
     monkeypatch.setattr(main, "ping_db", ping_mock)
     monkeypatch.setattr(main.http_client, "start", start_mock)
     monkeypatch.setattr(main.http_client, "close", close_mock)
@@ -109,5 +120,39 @@ async def test_lifespan_fails_fast_after_max_retries(monkeypatch):
     assert ping_mock.call_count == 3
     assert sleep_mock.await_count == 2
     start_mock.assert_not_awaited()
+
+    # http client never started → should NOT be closed
     close_mock.assert_not_awaited()
-    dispose_mock.assert_not_called()
+
+    dispose_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_fails_if_http_client_fails(monkeypatch):
+    main = load_main_module(monkeypatch)
+
+    ping_mock = MagicMock(return_value=None)
+    to_thread_mock = AsyncMock(side_effect=lambda fn: fn())
+    start_mock = AsyncMock(side_effect=Exception("http client error"))
+    close_mock = AsyncMock()
+    dispose_mock = MagicMock()
+    sleep_mock = AsyncMock()
+
+    monkeypatch.setattr(main, "MAX_RETRIES", 3)
+    monkeypatch.setattr(main.asyncio, "to_thread", to_thread_mock)
+    monkeypatch.setattr(main, "ping_db", ping_mock)
+    monkeypatch.setattr(main.http_client, "start", start_mock)
+    monkeypatch.setattr(main.http_client, "close", close_mock)
+    monkeypatch.setattr(main.engine, "dispose", dispose_mock)
+    monkeypatch.setattr(main.asyncio, "sleep", sleep_mock)
+
+    with pytest.raises(Exception, match="http client error"):
+        async with main.lifespan(main.app):
+            pass
+
+    start_mock.assert_awaited_once()
+
+    # client never successfully started → should NOT be closed
+    close_mock.assert_not_awaited()
+
+    dispose_mock.assert_called_once()

--- a/tool/backend/test/test_startup_db_lifespan.py
+++ b/tool/backend/test/test_startup_db_lifespan.py
@@ -1,0 +1,113 @@
+import importlib
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+REQUIRED_ENV = {
+    "ALLOWED_ORIGINS": "http://localhost:5173",
+    "POSTGRES_HOST": "localhost:5432",
+    "POSTGRES_USER": "rti",
+    "POSTGRES_PASSWORD": "rti",
+    "POSTGRES_DB": "rti",
+    "ASGARDEO_ORG": "org",
+    "CLIENT_ID": "client-id",
+    "CLIENT_SECRET": "client-secret",
+    "GITHUB_TOKEN": "token",
+    "GITHUB_REPO_NAME": "repo",
+    "GITHUB_BRANCH": "main",
+}
+
+
+def load_main_module(monkeypatch):
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    if "main" in sys.modules:
+        del sys.modules["main"]
+
+    return importlib.import_module("main")
+
+
+@pytest.mark.asyncio
+async def test_lifespan_starts_when_db_ping_succeeds(monkeypatch):
+    main = load_main_module(monkeypatch)
+
+    ping_mock = MagicMock(return_value=None)
+    start_mock = AsyncMock()
+    close_mock = AsyncMock()
+    dispose_mock = MagicMock()
+    sleep_mock = AsyncMock()
+
+    monkeypatch.setattr(main, "MAX_RETRIES", 3)
+    monkeypatch.setattr(main, "ping_db", ping_mock)
+    monkeypatch.setattr(main.http_client, "start", start_mock)
+    monkeypatch.setattr(main.http_client, "close", close_mock)
+    monkeypatch.setattr(main.engine, "dispose", dispose_mock)
+    monkeypatch.setattr(main.asyncio, "sleep", sleep_mock)
+
+    async with main.lifespan(main.app):
+        pass
+
+    assert ping_mock.call_count == 1
+    start_mock.assert_awaited_once()
+    close_mock.assert_awaited_once()
+    dispose_mock.assert_called_once()
+    sleep_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_retries_then_succeeds(monkeypatch):
+    main = load_main_module(monkeypatch)
+
+    ping_mock = MagicMock(side_effect=[Exception("db down"), None])
+    start_mock = AsyncMock()
+    close_mock = AsyncMock()
+    dispose_mock = MagicMock()
+    sleep_mock = AsyncMock()
+
+    monkeypatch.setattr(main, "MAX_RETRIES", 3)
+    monkeypatch.setattr(main, "RETRY_DELAY", 0)
+    monkeypatch.setattr(main, "ping_db", ping_mock)
+    monkeypatch.setattr(main.http_client, "start", start_mock)
+    monkeypatch.setattr(main.http_client, "close", close_mock)
+    monkeypatch.setattr(main.engine, "dispose", dispose_mock)
+    monkeypatch.setattr(main.asyncio, "sleep", sleep_mock)
+
+    async with main.lifespan(main.app):
+        pass
+
+    assert ping_mock.call_count == 2
+    sleep_mock.assert_awaited_once_with(0)
+    start_mock.assert_awaited_once()
+    close_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_fails_fast_after_max_retries(monkeypatch):
+    main = load_main_module(monkeypatch)
+
+    ping_mock = MagicMock(side_effect=Exception("db down"))
+    start_mock = AsyncMock()
+    close_mock = AsyncMock()
+    dispose_mock = MagicMock()
+    sleep_mock = AsyncMock()
+
+    monkeypatch.setattr(main, "MAX_RETRIES", 3)
+    monkeypatch.setattr(main, "RETRY_DELAY", 0)
+    monkeypatch.setattr(main, "ping_db", ping_mock)
+    monkeypatch.setattr(main.http_client, "start", start_mock)
+    monkeypatch.setattr(main.http_client, "close", close_mock)
+    monkeypatch.setattr(main.engine, "dispose", dispose_mock)
+    monkeypatch.setattr(main.asyncio, "sleep", sleep_mock)
+
+    with pytest.raises(RuntimeError, match="Cannot connect to database"):
+        async with main.lifespan(main.app):
+            pass
+
+    assert ping_mock.call_count == 3
+    assert sleep_mock.await_count == 2
+    start_mock.assert_not_awaited()
+    close_mock.assert_not_awaited()
+    dispose_mock.assert_not_called()


### PR DESCRIPTION
This pull request introduces a robust, bounded-retry mechanism for database connectivity during application startup, ensuring the backend only starts if the database is reachable within a configurable number of attempts. It also adds comprehensive tests to verify this startup behavior under different scenarios.

**Database startup reliability improvements:**

* Added `MAX_RETRIES` and `RETRY_DELAY` settings to `.env.example` and `Settings` in `configs.py`, making the number of connection attempts and delay between them configurable via environment variables. [[1]](diffhunk://#diff-721d716954aa37b44f30ed11151f4660a1ecf5c653035c4f986c4f30f737b762R11-R14) [[2]](diffhunk://#diff-19010d31cb901b79cda41e3d6349eb79f53e01eaf24391f205e35b95cab70227R14-R17)
* Updated `main.py` to implement a retry loop in the `lifespan` context manager, attempting to connect to the database up to `MAX_RETRIES` times with a delay of `RETRY_DELAY` seconds between attempts, aborting startup if all attempts fail.

**Testing and validation:**

* Added `test_startup_db_lifespan.py` with tests to verify: 
  - Immediate success when the database is available,
  - Retry logic when the database is temporarily unavailable,
  - Proper failure after exhausting all retries.


closes #60 