### PR TITLE
Alias and Serialization alias added for the missing models

### DIFF
--- a/tool/backend/src/models/common/common.py
+++ b/tool/backend/src/models/common/common.py
@@ -4,6 +4,6 @@ class PaginationModel(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
     # attributes
     page: int = Field(1, ge=1, description="Current page number (1-indexed)")
-    pageSize: int = Field(10, ge=1, le=100, description="Number of items per page")
-    totalItems: int = Field(0, ge=0, description="Total number of items available")
-    totalPages: int = Field(0, ge=0, description="Total number of pages based on pageSize")
+    page_size: int = Field(10, ge=1, serialization_alias="pageSize", le=100, description="Number of items per page")
+    total_items: int = Field(0, ge=0, serialization_alias="totalItems", description="Total number of items available")
+    total_pages: int = Field(0, ge=0, serialization_alias="totalPages", description="Total number of pages based on pageSize")

--- a/tool/backend/src/models/common/common.py
+++ b/tool/backend/src/models/common/common.py
@@ -5,5 +5,5 @@ class PaginationModel(BaseModel):
     # attributes
     page: int = Field(1, ge=1, description="Current page number (1-indexed)")
     pageSize: int = Field(10, ge=1, le=100, description="Number of items per page")
-    totalItem: int = Field(0, ge=0, description="Total number of items available")
+    totalItems: int = Field(0, ge=0, description="Total number of items available")
     totalPages: int = Field(0, ge=0, description="Total number of pages based on pageSize")

--- a/tool/backend/src/models/request_models/senders.py
+++ b/tool/backend/src/models/request_models/senders.py
@@ -4,7 +4,7 @@ from src.core.exceptions import BadRequestException
 
 
 class SenderRequest(BaseModel):
-    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True, populate_by_name=True)
     # attributes
     name: str = Field(..., json_schema_extra={"example":"John Doe"}, description="Name of the sender.")
     email: Optional[EmailStr] = Field(
@@ -14,7 +14,7 @@ class SenderRequest(BaseModel):
         None, json_schema_extra={"example":"123 Main St, Colombo 01"}, description="Address of the sender."
     )
     contact_no: Optional[str] = Field(
-        None, pattern=r"^(?:\+94|0)\d{9}$", serialization_alias="contactNo", json_schema_extra={"example":"0771234567"}, description="Contact number of the sender."
+        None, pattern=r"^(?:\+94|0)\d{9}$", alias="contactNo", json_schema_extra={"example":"0771234567"}, description="Contact number of the sender."
     )
 
     # either email or contact_no must be provided

--- a/tool/backend/src/models/response_models/institutions.py
+++ b/tool/backend/src/models/response_models/institutions.py
@@ -9,8 +9,8 @@ class InstitutionResponse(BaseModel):
     # attributes
     id: UUID = Field(..., description="Unique identifier for the institution")
     name: str = Field(..., description="Name of the institution")
-    created_at: datetime = Field(..., description="ISO 8601 timestamp of when the institution was created")
-    updated_at: datetime = Field(..., description="ISO 8601 timestamp of when the institution was last updated")
+    created_at: datetime = Field(..., serialization_alias="createdAt", description="ISO 8601 timestamp of when the institution was created")
+    updated_at: datetime = Field(..., serialization_alias="updatedAt", description="ISO 8601 timestamp of when the institution was last updated")
 
 class InstitutionShortResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)

--- a/tool/backend/src/models/response_models/rti_templates.py
+++ b/tool/backend/src/models/response_models/rti_templates.py
@@ -14,8 +14,8 @@ class RTITemplateResponse(BaseModel):
     title: str = Field(..., description="Title of the RTI template")
     description: Optional[str] = Field(None, description="Detailed description of the RTI template")
     file: str = Field(..., description="Relative path of the markdown file")
-    created_at: datetime = Field(..., description="ISO 8601 timestamp of when the template was created")
-    updated_at: datetime = Field(..., description="ISO 8601 timestamp of when the template was last updated")
+    created_at: datetime = Field(..., serialization_alias="createdAt", description="ISO 8601 timestamp of when the template was created")
+    updated_at: datetime = Field(..., serialization_alias="updatedAt", description="ISO 8601 timestamp of when the template was last updated")
 
 
 class RTITemplateShortResponse(BaseModel):

--- a/tool/backend/src/routers/institution_router.py
+++ b/tool/backend/src/routers/institution_router.py
@@ -18,7 +18,7 @@ def get_institution_service(session: SessionDep):
 @router.get("/institutions", response_model=InstitutionListResponse)
 def get_institutions_endpoint(
     page: int = Query(1, ge=1, description="page number"),
-    page_size: int = Query(10, ge=1, le=100, description="page size"),
+    page_size: int = Query(10, ge=1, le=100, alias="pageSize", description="page size"),
     service: InstitutionService = Depends(get_institution_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
     ):

--- a/tool/backend/src/routers/position_router.py
+++ b/tool/backend/src/routers/position_router.py
@@ -16,7 +16,7 @@ def get_position_service(session: SessionDep):
 @router.get("/positions", response_model=PositionListResponse)
 def get_positions_endpoint(
     page: int = Query(1, ge=1, description="page number"),
-    page_size: int = Query(10, ge=1, le=100, description="page size"),
+    page_size: int = Query(10, ge=1, le=100, alias="pageSize", description="page size"),
     service: PositionService = Depends(get_position_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
     ):

--- a/tool/backend/src/routers/receiver_router.py
+++ b/tool/backend/src/routers/receiver_router.py
@@ -23,7 +23,7 @@ def create_receiver_endpoint(
 @router.get("/receivers", response_model=ReceiverListResponse)
 def get_receiver_endpoint(
     page: int = Query(1, ge=1, description="page number"),
-    page_size: int = Query(10, ge=1, le=100, description="page size"),
+    page_size: int = Query(10, ge=1, le=100, alias="pageSize", description="page size"),
     service: ReceiverService = Depends(get_receiver_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):

--- a/tool/backend/src/routers/rti_request_router.py
+++ b/tool/backend/src/routers/rti_request_router.py
@@ -20,7 +20,7 @@ def get_rti_request_service(session: SessionDep, file_service: GithubFileService
 @router.get("/rti_requests", response_model=RTIRequestListResponse)
 async def get_rti_requests_endpoint(
     page: int = Query(1, ge=1, description="page number"),
-    page_size: int = Query(10, ge=1, le=100, description="page size"),
+    page_size: int = Query(10, ge=1, le=100, alias="pageSize", description="page size"),
     service: RTIRequestService = Depends(get_rti_request_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):

--- a/tool/backend/src/routers/rti_template_router.py
+++ b/tool/backend/src/routers/rti_template_router.py
@@ -18,7 +18,7 @@ def get_rti_template_service(session: SessionDep, file_service: GithubFileServic
 @router.get("/rti_templates", response_model=RTITemplateListResponse)
 async def get_rti_templates_endpoint(
     page: int = Query(1, ge=1, description="page number"),
-    page_size: int = Query(10, ge=1, le=100, description="page size"),
+    page_size: int = Query(10, ge=1, le=100, alias="pageSize", description="page size"),
     service: RTITemplateService = Depends(get_rti_template_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
     ):

--- a/tool/backend/src/routers/sender_router.py
+++ b/tool/backend/src/routers/sender_router.py
@@ -23,7 +23,7 @@ def create_sender_endpoint(
 @router.get("/senders", response_model=SenderListResponse)
 def get_sender_list_endpoint(
     page: int = Query(1, ge=1, description="page number"),
-    page_size: int = Query(10, ge=1, le=100, description="page size"),
+    page_size: int = Query(10, ge=1, le=100, alias="pageSize", description="page size"),
     service: SenderService = Depends(get_sender_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):

--- a/tool/backend/src/services/institution_service.py
+++ b/tool/backend/src/services/institution_service.py
@@ -37,9 +37,9 @@ class InstitutionService:
             # pagination response
             pagination = PaginationModel(
                 page=page,
-                pageSize=page_size,
-                totalItems=total_items,
-                totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
+                page_size=page_size,
+                total_items=total_items,
+                total_pages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             
             # return the final response

--- a/tool/backend/src/services/institution_service.py
+++ b/tool/backend/src/services/institution_service.py
@@ -38,7 +38,7 @@ class InstitutionService:
             pagination = PaginationModel(
                 page=page,
                 pageSize=page_size,
-                totalItem=total_items,
+                totalItems=total_items,
                 totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             

--- a/tool/backend/src/services/position_service.py
+++ b/tool/backend/src/services/position_service.py
@@ -40,9 +40,9 @@ class PositionService:
             # pagination response
             pagination = PaginationModel(
                 page=page,
-                pageSize=page_size,
-                totalItems=total_items,
-                totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
+                page_size=page_size,
+                total_items=total_items,
+                total_pages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             
             # return the final response

--- a/tool/backend/src/services/position_service.py
+++ b/tool/backend/src/services/position_service.py
@@ -41,7 +41,7 @@ class PositionService:
             pagination = PaginationModel(
                 page=page,
                 pageSize=page_size,
-                totalItem=total_items,
+                totalItems=total_items,
                 totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             

--- a/tool/backend/src/services/receiver_service.py
+++ b/tool/backend/src/services/receiver_service.py
@@ -76,9 +76,9 @@ class ReceiverService:
             # pagination response
             pagination = PaginationModel(
                 page=page,
-                pageSize=page_size,
-                totalItems=total_items,
-                totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
+                page_size=page_size,
+                total_items=total_items,
+                total_pages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             
             # return the final response

--- a/tool/backend/src/services/receiver_service.py
+++ b/tool/backend/src/services/receiver_service.py
@@ -77,7 +77,7 @@ class ReceiverService:
             pagination = PaginationModel(
                 page=page,
                 pageSize=page_size,
-                totalItem=total_items,
+                totalItems=total_items,
                 totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             

--- a/tool/backend/src/services/rti_request_service.py
+++ b/tool/backend/src/services/rti_request_service.py
@@ -142,9 +142,9 @@ class RTIRequestService:
             # pagination response
             pagination = PaginationModel(
                 page=page,
-                pageSize=page_size,
-                totalItems=total_items,
-                totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
+                page_size=page_size,
+                total_items=total_items,
+                total_pages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             
             # return the final response

--- a/tool/backend/src/services/rti_request_service.py
+++ b/tool/backend/src/services/rti_request_service.py
@@ -143,7 +143,7 @@ class RTIRequestService:
             pagination = PaginationModel(
                 page=page,
                 pageSize=page_size,
-                totalItem=total_items,
+                totalItems=total_items,
                 totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -42,9 +42,9 @@ class RTITemplateService:
             # pagination response
             pagination = PaginationModel(
                 page=page,
-                pageSize=page_size,
-                totalItems=total_items,
-                totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
+                page_size=page_size,
+                total_items=total_items,
+                total_pages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             
             # return the final response

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -43,7 +43,7 @@ class RTITemplateService:
             pagination = PaginationModel(
                 page=page,
                 pageSize=page_size,
-                totalItem=total_items,
+                totalItems=total_items,
                 totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             

--- a/tool/backend/src/services/sender_service.py
+++ b/tool/backend/src/services/sender_service.py
@@ -78,9 +78,9 @@ class SenderService:
             # pagination response
             pagination = PaginationModel(
                 page=page,
-                pageSize=page_size,
-                totalItems=total_items,
-                totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
+                page_size=page_size,
+                total_items=total_items,
+                total_pages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             
             # return the final response

--- a/tool/backend/src/services/sender_service.py
+++ b/tool/backend/src/services/sender_service.py
@@ -79,7 +79,7 @@ class SenderService:
             pagination = PaginationModel(
                 page=page,
                 pageSize=page_size,
-                totalItem=total_items,
+                totalItems=total_items,
                 totalPages=(total_items + page_size - 1) // page_size if total_items > 0 else 0
             )
             

--- a/tool/backend/test/test_institution_service.py
+++ b/tool/backend/test/test_institution_service.py
@@ -17,9 +17,9 @@ def test_get_institutions_default(institution_db):
     
     assert isinstance(response, InstitutionListResponse)
     assert response.pagination.page == 1
-    assert response.pagination.pageSize == 10
-    assert response.pagination.totalItems == 3
-    assert response.pagination.totalPages == 1
+    assert response.pagination.page_size == 10
+    assert response.pagination.total_items == 3
+    assert response.pagination.total_pages == 1
     assert len(response.data) == 3
     # verify sorting order (descending by created_at)
     # Institution 3 (now) should be first, Institution 1 (now - 2h) should be last
@@ -33,9 +33,9 @@ def test_get_institutions_custom_pagination(institution_db):
     response = service.get_institutions(page=2, page_size=2)
     
     assert response.pagination.page == 2
-    assert response.pagination.pageSize == 2
-    assert response.pagination.totalItems == 3
-    assert response.pagination.totalPages == 2
+    assert response.pagination.page_size == 2
+    assert response.pagination.total_items == 3
+    assert response.pagination.total_pages == 2
     assert len(response.data) == 1  # Only 1 record left for page 2
 
 def test_get_institutions_empty_db():
@@ -46,8 +46,8 @@ def test_get_institutions_empty_db():
         service = InstitutionService(session=session)
         response = service.get_institutions()
         
-        assert response.pagination.totalItems == 0
-        assert response.pagination.totalPages == 0
+        assert response.pagination.total_items == 0
+        assert response.pagination.total_pages == 0
         assert response.data == []
 
 def test_get_institutions_db_error(monkeypatch, institution_db):

--- a/tool/backend/test/test_institution_service.py
+++ b/tool/backend/test/test_institution_service.py
@@ -18,7 +18,7 @@ def test_get_institutions_default(institution_db):
     assert isinstance(response, InstitutionListResponse)
     assert response.pagination.page == 1
     assert response.pagination.pageSize == 10
-    assert response.pagination.totalItem == 3
+    assert response.pagination.totalItems == 3
     assert response.pagination.totalPages == 1
     assert len(response.data) == 3
     # verify sorting order (descending by created_at)
@@ -34,7 +34,7 @@ def test_get_institutions_custom_pagination(institution_db):
     
     assert response.pagination.page == 2
     assert response.pagination.pageSize == 2
-    assert response.pagination.totalItem == 3
+    assert response.pagination.totalItems == 3
     assert response.pagination.totalPages == 2
     assert len(response.data) == 1  # Only 1 record left for page 2
 
@@ -46,7 +46,7 @@ def test_get_institutions_empty_db():
         service = InstitutionService(session=session)
         response = service.get_institutions()
         
-        assert response.pagination.totalItem == 0
+        assert response.pagination.totalItems == 0
         assert response.pagination.totalPages == 0
         assert response.data == []
 

--- a/tool/backend/test/test_position_service.py
+++ b/tool/backend/test/test_position_service.py
@@ -24,9 +24,9 @@ def test_get_positions_default(position_db):
 
     assert isinstance(response, PositionListResponse)
     assert response.pagination.page == 1
-    assert response.pagination.pageSize == 10
-    assert response.pagination.totalItems == 3
-    assert response.pagination.totalPages == 1
+    assert response.pagination.page_size == 10
+    assert response.pagination.total_items == 3
+    assert response.pagination.total_pages == 1
     assert len(response.data) == 3
     assert response.data[0].name == "Position 3"
     assert response.data[1].name == "Position 2"
@@ -39,9 +39,9 @@ def test_get_positions_custom_pagination(position_db):
     response = service.get_positions(page=2, page_size=2)
 
     assert response.pagination.page == 2
-    assert response.pagination.pageSize == 2
-    assert response.pagination.totalItems == 3
-    assert response.pagination.totalPages == 2
+    assert response.pagination.page_size == 2
+    assert response.pagination.total_items == 3
+    assert response.pagination.total_pages == 2
     assert len(response.data) == 1
 
 
@@ -53,8 +53,8 @@ def test_get_positions_empty_db():
         service = PositionService(session=session)
         response = service.get_positions()
 
-        assert response.pagination.totalItems == 0
-        assert response.pagination.totalPages == 0
+        assert response.pagination.total_items == 0
+        assert response.pagination.total_pages == 0
         assert response.data == []
 
 

--- a/tool/backend/test/test_position_service.py
+++ b/tool/backend/test/test_position_service.py
@@ -25,7 +25,7 @@ def test_get_positions_default(position_db):
     assert isinstance(response, PositionListResponse)
     assert response.pagination.page == 1
     assert response.pagination.pageSize == 10
-    assert response.pagination.totalItem == 3
+    assert response.pagination.totalItems == 3
     assert response.pagination.totalPages == 1
     assert len(response.data) == 3
     assert response.data[0].name == "Position 3"
@@ -40,7 +40,7 @@ def test_get_positions_custom_pagination(position_db):
 
     assert response.pagination.page == 2
     assert response.pagination.pageSize == 2
-    assert response.pagination.totalItem == 3
+    assert response.pagination.totalItems == 3
     assert response.pagination.totalPages == 2
     assert len(response.data) == 1
 
@@ -53,7 +53,7 @@ def test_get_positions_empty_db():
         service = PositionService(session=session)
         response = service.get_positions()
 
-        assert response.pagination.totalItem == 0
+        assert response.pagination.totalItems == 0
         assert response.pagination.totalPages == 0
         assert response.data == []
 

--- a/tool/backend/test/test_receiver_service.py
+++ b/tool/backend/test/test_receiver_service.py
@@ -15,9 +15,9 @@ def test_get_receivers_default(receiver_db):
     
     assert isinstance(response, ReceiverListResponse)
     assert response.pagination.page == 1
-    assert response.pagination.pageSize == 10
-    assert response.pagination.totalItems == 3
-    assert response.pagination.totalPages == 1
+    assert response.pagination.page_size == 10
+    assert response.pagination.total_items == 3
+    assert response.pagination.total_pages == 1
     assert len(response.data) == 3
     # verify sorting order (descending by created_at)
     # Receiver 3 (now) should be first, Receiver 1 (now - 2h) should be last
@@ -35,9 +35,9 @@ def test_get_receivers_custom_pagination(receiver_db):
     response = service.get_receivers(page=2, page_size=2)
     
     assert response.pagination.page == 2
-    assert response.pagination.pageSize == 2
-    assert response.pagination.totalItems == 3
-    assert response.pagination.totalPages == 2
+    assert response.pagination.page_size == 2
+    assert response.pagination.total_items == 3
+    assert response.pagination.total_pages == 2
     assert len(response.data) == 1  # Only 1 record left for page 2
     assert response.data[0].email == "receiver1@example.com"
 
@@ -49,8 +49,8 @@ def test_get_receivers_empty_db():
         service = ReceiverService(session=session)
         response = service.get_receivers()
         
-        assert response.pagination.totalItems == 0
-        assert response.pagination.totalPages == 0
+        assert response.pagination.total_items == 0
+        assert response.pagination.total_pages == 0
         assert response.data == []
 
 def test_get_receivers_db_error(monkeypatch, receiver_db):

--- a/tool/backend/test/test_receiver_service.py
+++ b/tool/backend/test/test_receiver_service.py
@@ -16,7 +16,7 @@ def test_get_receivers_default(receiver_db):
     assert isinstance(response, ReceiverListResponse)
     assert response.pagination.page == 1
     assert response.pagination.pageSize == 10
-    assert response.pagination.totalItem == 3
+    assert response.pagination.totalItems == 3
     assert response.pagination.totalPages == 1
     assert len(response.data) == 3
     # verify sorting order (descending by created_at)
@@ -36,7 +36,7 @@ def test_get_receivers_custom_pagination(receiver_db):
     
     assert response.pagination.page == 2
     assert response.pagination.pageSize == 2
-    assert response.pagination.totalItem == 3
+    assert response.pagination.totalItems == 3
     assert response.pagination.totalPages == 2
     assert len(response.data) == 1  # Only 1 record left for page 2
     assert response.data[0].email == "receiver1@example.com"
@@ -49,7 +49,7 @@ def test_get_receivers_empty_db():
         service = ReceiverService(session=session)
         response = service.get_receivers()
         
-        assert response.pagination.totalItem == 0
+        assert response.pagination.totalItems == 0
         assert response.pagination.totalPages == 0
         assert response.data == []
 

--- a/tool/backend/test/test_rti_request_service.py
+++ b/tool/backend/test/test_rti_request_service.py
@@ -255,10 +255,10 @@ async def test_get_rti_requests_success(rti_request_db, make_file_service, make_
     response = service.get_rti_requests(page=1, page_size=2)
     
     assert len(response.data) == 2
-    assert response.pagination.totalItems == 3
-    assert response.pagination.totalPages == 2
+    assert response.pagination.total_items == 3
+    assert response.pagination.total_pages == 2
     assert response.pagination.page == 1
-    assert response.pagination.pageSize == 2
+    assert response.pagination.page_size == 2
 
 @pytest.mark.asyncio
 async def test_get_rti_requests_empty_db(make_file_service):
@@ -270,8 +270,8 @@ async def test_get_rti_requests_empty_db(make_file_service):
         response = service.get_rti_requests()
         
         assert response.pagination.page == 1
-        assert response.pagination.totalItems == 0
-        assert response.pagination.totalPages == 0
+        assert response.pagination.total_items == 0
+        assert response.pagination.total_pages == 0
         assert response.data == []
 
 @pytest.mark.asyncio

--- a/tool/backend/test/test_rti_request_service.py
+++ b/tool/backend/test/test_rti_request_service.py
@@ -255,7 +255,7 @@ async def test_get_rti_requests_success(rti_request_db, make_file_service, make_
     response = service.get_rti_requests(page=1, page_size=2)
     
     assert len(response.data) == 2
-    assert response.pagination.totalItem == 3
+    assert response.pagination.totalItems == 3
     assert response.pagination.totalPages == 2
     assert response.pagination.page == 1
     assert response.pagination.pageSize == 2
@@ -270,7 +270,7 @@ async def test_get_rti_requests_empty_db(make_file_service):
         response = service.get_rti_requests()
         
         assert response.pagination.page == 1
-        assert response.pagination.totalItem == 0
+        assert response.pagination.totalItems == 0
         assert response.pagination.totalPages == 0
         assert response.data == []
 

--- a/tool/backend/test/test_rti_template_service.py
+++ b/tool/backend/test/test_rti_template_service.py
@@ -17,9 +17,9 @@ async def test_get_rti_templates_default(rti_template_db, make_file_service):
     response = service.get_rti_templates()
     
     assert response.pagination.page == 1
-    assert response.pagination.pageSize == 10
-    assert response.pagination.totalItems == 3
-    assert response.pagination.totalPages == 1
+    assert response.pagination.page_size == 10
+    assert response.pagination.total_items == 3
+    assert response.pagination.total_pages == 1
     assert len(response.data) == 3
 
 @pytest.mark.asyncio
@@ -30,9 +30,9 @@ async def test_get_rti_templates_custom_page(rti_template_db, make_file_service)
     response = service.get_rti_templates(page=2, page_size=2)
     
     assert response.pagination.page == 2
-    assert response.pagination.pageSize == 2
-    assert response.pagination.totalItems == 3
-    assert response.pagination.totalPages == 2
+    assert response.pagination.page_size == 2
+    assert response.pagination.total_items == 3
+    assert response.pagination.total_pages == 2
     assert len(response.data) == 1  # Only one record left on page 2
 
 @pytest.mark.asyncio
@@ -47,8 +47,8 @@ async def test_get_rti_templates_empty_db(make_file_service):
         response = service.get_rti_templates()
         
         assert response.pagination.page == 1
-        assert response.pagination.totalItems == 0
-        assert response.pagination.totalPages == 0
+        assert response.pagination.total_items == 0
+        assert response.pagination.total_pages == 0
         assert response.data == []
 
 @pytest.mark.asyncio
@@ -62,7 +62,7 @@ async def test_get_rti_templates_page_out_of_bounds(rti_template_db, make_file_s
     assert response.pagination.page == 10
     assert response.data == []
     # totalPages still correctly reflects actual data
-    assert response.pagination.totalPages == 2
+    assert response.pagination.total_pages == 2
 
 @pytest.mark.asyncio
 async def test_get_rti_templates_raises_internal_exception(monkeypatch, rti_template_db, make_file_service):

--- a/tool/backend/test/test_rti_template_service.py
+++ b/tool/backend/test/test_rti_template_service.py
@@ -18,7 +18,7 @@ async def test_get_rti_templates_default(rti_template_db, make_file_service):
     
     assert response.pagination.page == 1
     assert response.pagination.pageSize == 10
-    assert response.pagination.totalItem == 3
+    assert response.pagination.totalItems == 3
     assert response.pagination.totalPages == 1
     assert len(response.data) == 3
 
@@ -31,7 +31,7 @@ async def test_get_rti_templates_custom_page(rti_template_db, make_file_service)
     
     assert response.pagination.page == 2
     assert response.pagination.pageSize == 2
-    assert response.pagination.totalItem == 3
+    assert response.pagination.totalItems == 3
     assert response.pagination.totalPages == 2
     assert len(response.data) == 1  # Only one record left on page 2
 
@@ -47,7 +47,7 @@ async def test_get_rti_templates_empty_db(make_file_service):
         response = service.get_rti_templates()
         
         assert response.pagination.page == 1
-        assert response.pagination.totalItem == 0
+        assert response.pagination.totalItems == 0
         assert response.pagination.totalPages == 0
         assert response.data == []
 

--- a/tool/backend/test/test_sender_service.py
+++ b/tool/backend/test/test_sender_service.py
@@ -225,14 +225,14 @@ def test_get_sender_list_pagination_total_items(sender_db):
     service = SenderService(session=sender_db)
     result = service.get_sender_list(page=1, page_size=10)
 
-    assert result.pagination.totalItems == 3
+    assert result.pagination.total_items == 3
 
 
 def test_get_sender_list_pagination_total_pages(sender_db):
     service = SenderService(session=sender_db)
     result = service.get_sender_list(page=1, page_size=2)
 
-    assert result.pagination.totalPages == 2
+    assert result.pagination.total_pages == 2
 
 
 def test_get_sender_list_pagination_reflects_page_and_size(sender_db):
@@ -240,7 +240,7 @@ def test_get_sender_list_pagination_reflects_page_and_size(sender_db):
     result = service.get_sender_list(page=2, page_size=2)
 
     assert result.pagination.page == 2
-    assert result.pagination.pageSize == 2
+    assert result.pagination.page_size == 2
 
 
 def test_get_sender_list_page_size_limits_results(sender_db):
@@ -281,8 +281,8 @@ def test_get_sender_list_empty_db_returns_empty_data():
         result = service.get_sender_list()
 
     assert len(result.data) == 0
-    assert result.pagination.totalItems == 0
-    assert result.pagination.totalPages == 0
+    assert result.pagination.total_items == 0
+    assert result.pagination.total_pages == 0
 
 
 def test_get_sender_list_raises_internal_on_db_error(monkeypatch, sender_db):

--- a/tool/backend/test/test_sender_service.py
+++ b/tool/backend/test/test_sender_service.py
@@ -225,7 +225,7 @@ def test_get_sender_list_pagination_total_items(sender_db):
     service = SenderService(session=sender_db)
     result = service.get_sender_list(page=1, page_size=10)
 
-    assert result.pagination.totalItem == 3
+    assert result.pagination.totalItems == 3
 
 
 def test_get_sender_list_pagination_total_pages(sender_db):
@@ -281,7 +281,7 @@ def test_get_sender_list_empty_db_returns_empty_data():
         result = service.get_sender_list()
 
     assert len(result.data) == 0
-    assert result.pagination.totalItem == 0
+    assert result.pagination.totalItems == 0
     assert result.pagination.totalPages == 0
 
 


### PR DESCRIPTION
- Some request and response models were missing schema serialization. This PR contains changes for those model serialization issues. 
- The `pagination` model previously had `totalItem` and has now been updated to `totalItems`.