### PR TITLE
[RTI][TOOL][BACKEND] RTI Request History Management APIs

### DIFF
--- a/tool/backend/main.py
+++ b/tool/backend/main.py
@@ -1,5 +1,9 @@
 import asyncio
 import logging
+from src.utils.http_client import http_client
+from src.routers import rti_template_router, institution_router, position_router, sender_router, receiver_router, rti_request_router, rti_status_router, rti_request_history_router
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -124,6 +128,7 @@ app.include_router(sender_router)
 app.include_router(receiver_router)
 app.include_router(rti_request_router)
 app.include_router(rti_status_router)
+app.include_router(rti_request_history_router)
 
 app.add_exception_handler(BaseAPIException, api_exception_handler)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)

--- a/tool/backend/src/models/__init__.py
+++ b/tool/backend/src/models/__init__.py
@@ -1,7 +1,7 @@
-from .table_schemas import RTITemplate, Sender, Institution, Position, Receiver, RTIRequest, RTIStatus, RTIStatusHistories, RTIStatusName
+from .table_schemas import RTITemplate, Sender, Institution, Position, Receiver, RTIRequest, RTIStatus, RTIStatusHistories, RTIStatusName, RTIDirection
 from .common import User, PaginationModel, UserRole
 from .request_models import SenderRequest, ReceiverRequest, ReceiverUpdateRequest, RTIStatusRequest
-from .response_models import SenderResponse, SenderListResponse, RTIStatusResponse, RTIStatusListResponse
+from .response_models import SenderResponse, SenderListResponse, RTIStatusResponse, RTIStatusListResponse, RTIRequestHistoryListResponse, RTIRequestHistoryResponse, RTIStatusShortResponse
 
 __all__ = [
     "RTITemplate",
@@ -23,5 +23,9 @@ __all__ = [
     "RTIStatusHistories",
     "SenderListResponse",
     "ReceiverUpdateRequest",
-    "RTIStatusName"
+    "RTIStatusName",
+    "RTIDirection",
+    "RTIRequestHistoryListResponse",
+    "RTIRequestHistoryResponse",
+    "RTIStatusShortResponse"
 ]

--- a/tool/backend/src/models/__init__.py
+++ b/tool/backend/src/models/__init__.py
@@ -1,6 +1,6 @@
 from .table_schemas import RTITemplate, Sender, Institution, Position, Receiver, RTIRequest, RTIStatus, RTIStatusHistories, RTIStatusName, RTIDirection
 from .common import User, PaginationModel, UserRole
-from .request_models import SenderRequest, ReceiverRequest, ReceiverUpdateRequest, RTIStatusRequest, RTIRequestHistoryRequest
+from .request_models import SenderRequest, ReceiverRequest, ReceiverUpdateRequest, RTIStatusRequest, RTIRequestHistoryRequest, RTIRequestHistoryUpdateRequest
 from .response_models import SenderResponse, SenderListResponse, RTIStatusResponse, RTIStatusListResponse, RTIRequestHistoryListResponse, RTIRequestHistoryResponse, RTIStatusShortResponse
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     "RTIStatusListResponse",
     "ReceiverRequest",
     "RTIRequestHistoryRequest",
+    "RTIRequestHistoryUpdateRequest",
     "SenderResponse",
     "Sender",
     "Receiver",

--- a/tool/backend/src/models/__init__.py
+++ b/tool/backend/src/models/__init__.py
@@ -1,6 +1,6 @@
 from .table_schemas import RTITemplate, Sender, Institution, Position, Receiver, RTIRequest, RTIStatus, RTIStatusHistories, RTIStatusName, RTIDirection
 from .common import User, PaginationModel, UserRole
-from .request_models import SenderRequest, ReceiverRequest, ReceiverUpdateRequest, RTIStatusRequest
+from .request_models import SenderRequest, ReceiverRequest, ReceiverUpdateRequest, RTIStatusRequest, RTIRequestHistoryRequest
 from .response_models import SenderResponse, SenderListResponse, RTIStatusResponse, RTIStatusListResponse, RTIRequestHistoryListResponse, RTIRequestHistoryResponse, RTIStatusShortResponse
 
 __all__ = [
@@ -15,6 +15,7 @@ __all__ = [
     "RTIStatusResponse",
     "RTIStatusListResponse",
     "ReceiverRequest",
+    "RTIRequestHistoryRequest",
     "SenderResponse",
     "Sender",
     "Receiver",

--- a/tool/backend/src/models/__init__.py
+++ b/tool/backend/src/models/__init__.py
@@ -1,4 +1,4 @@
-from .table_schemas import RTITemplate, Sender, Institution, Position, Receiver, RTIRequest, RTIStatus, RTIStatusHistories, RTIStatusName, RTIDirection
+from .table_schemas import RTITemplate, Sender, Institution, Position, Receiver, RTIRequest, RTIStatus, RTIStatusHistory, RTIStatusName, RTIDirection
 from .common import User, PaginationModel, UserRole
 from .request_models import SenderRequest, ReceiverRequest, ReceiverUpdateRequest, RTIStatusRequest, RTIRequestHistoryRequest, RTIRequestHistoryUpdateRequest
 from .response_models import SenderResponse, SenderListResponse, RTIStatusResponse, RTIStatusListResponse, RTIRequestHistoryListResponse, RTIRequestHistoryResponse, RTIStatusShortResponse
@@ -22,7 +22,7 @@ __all__ = [
     "Receiver",
     "RTIRequest",
     "RTIStatus",
-    "RTIStatusHistories",
+    "RTIStatusHistory",
     "SenderListResponse",
     "ReceiverUpdateRequest",
     "RTIStatusName",

--- a/tool/backend/src/models/request_models/__init__.py
+++ b/tool/backend/src/models/request_models/__init__.py
@@ -5,6 +5,7 @@ from .receiver import ReceiverRequest, ReceiverUpdateRequest
 from .positions import PositionRequest
 from .rti_requests import RTIRequestRequest, RTIRequestUpdateRequest
 from .rti_statuses import RTIStatusRequest
+from .rti_request_histories import RTIRequestHistoryRequest
 
 __all__ = [
     "SenderRequest",
@@ -15,6 +16,7 @@ __all__ = [
     "PositionRequest",
     "RTIRequestRequest",
     "RTIRequestUpdateRequest",
-    "RTIStatusRequest"
+    "RTIStatusRequest",
+    "RTIRequestHistoryRequest"
 ]
 

--- a/tool/backend/src/models/request_models/__init__.py
+++ b/tool/backend/src/models/request_models/__init__.py
@@ -5,7 +5,7 @@ from .receiver import ReceiverRequest, ReceiverUpdateRequest
 from .positions import PositionRequest
 from .rti_requests import RTIRequestRequest, RTIRequestUpdateRequest
 from .rti_statuses import RTIStatusRequest
-from .rti_request_histories import RTIRequestHistoryRequest
+from .rti_request_histories import RTIRequestHistoryRequest, RTIRequestHistoryUpdateRequest
 
 __all__ = [
     "SenderRequest",
@@ -17,6 +17,7 @@ __all__ = [
     "RTIRequestRequest",
     "RTIRequestUpdateRequest",
     "RTIStatusRequest",
-    "RTIRequestHistoryRequest"
+    "RTIRequestHistoryRequest",
+    "RTIRequestHistoryUpdateRequest"
 ]
 

--- a/tool/backend/src/models/request_models/rti_request_histories.py
+++ b/tool/backend/src/models/request_models/rti_request_histories.py
@@ -28,3 +28,14 @@ class RTIRequestHistoryRequest(BaseModel):
         if v is None or v == "":
             return datetime.now(timezone.utc)
         return v
+
+class RTIRequestHistoryUpdateRequest(BaseModel):
+    id: UUID = Field(..., description="ID of the RTI Status History record")
+    status_id: Optional[UUID] = Field(None, alias="statusId", description="ID of the RTI Status")
+    direction: Optional[RTIDirection] = Field(None, description="Direction of the RTI Status History (sent / received)")
+    description: Optional[str] = Field(None, description="Detailed description of the RTI Status History")
+    entry_time: Optional[datetime] = Field(None, alias="entryTime", description="Entry time for the RTI Status History")
+    exit_time: Optional[datetime] = Field(None, alias="exitTime", description="Exit time for the RTI Status History")
+    files_to_add: List[UploadFile] = Field([], alias="filesToAdd", description="New files to add (pdf only)")
+    files_to_delete: List[str] = Field([], alias="filesToDelete", description="Relative paths of files to delete")
+

--- a/tool/backend/src/models/request_models/rti_request_histories.py
+++ b/tool/backend/src/models/request_models/rti_request_histories.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timezone
+from typing import Optional, List
+from uuid import UUID
+from pydantic import BaseModel, Field, field_validator
+from fastapi import UploadFile
+
+from src.models.table_schemas.table_schemas import RTIDirection
+
+class RTIRequestHistoryRequest(BaseModel):
+    status_id: UUID = Field(..., alias="statusId", description="ID of the RTI Status")
+    direction: RTIDirection = Field(..., description="Direction of the RTI Status History (sent / received)")
+    description: Optional[str] = Field(None, description="Detailed description of the RTI Status History")
+    entry_time: Optional[datetime] = Field(
+        default=None, 
+        alias="entryTime", 
+        description="Entry time for the RTI Status History. Defaults to current time if not provided."
+    )
+    exit_time: Optional[datetime] = Field(
+        default=None,
+        alias="exitTime",
+        description="Exit time for the RTI Status History"
+    )
+    files: List[UploadFile] = Field([], description="List of files for the RTI Status History (pdf only)")
+
+    @field_validator("entry_time", mode="before")
+    @classmethod
+    def set_entry_time(cls, v):
+        if v is None or v == "":
+            return datetime.now(timezone.utc)
+        return v

--- a/tool/backend/src/models/response_models/__init__.py
+++ b/tool/backend/src/models/response_models/__init__.py
@@ -1,15 +1,18 @@
 from .rti_templates import RTITemplateResponse, RTITemplateListResponse, RTITemplateShortResponse
+from .rti_statuses import RTIStatusShortResponse
 from .institutions import InstitutionListResponse, InstitutionResponse, InstitutionShortResponse
 from .positions import PositionListResponse, PositionResponse, PositionShortResponse
 from .senders import SenderResponse, SenderListResponse, SenderShortResponse
 from .receivers import ReceiverListResponse, ReceiverResponse, ReceiverShortResponse
 from .rti_requests import RTIRequestResponse, RTIRequestListResponse
 from .rti_statuses import RTIStatusListResponse, RTIStatusResponse
+from .rti_request_histories import RTIRequestHistoryResponse, RTIRequestHistoryListResponse
 
 __all__ = [
     "RTITemplateResponse",
     "RTITemplateListResponse",
     "RTITemplateShortResponse",
+    "RTIStatusShortResponse",
     "SenderResponse",
     "SenderListResponse",
     "SenderShortResponse",
@@ -25,6 +28,8 @@ __all__ = [
     "RTIRequestResponse",
     "RTIRequestListResponse",
     "RTIStatusListResponse",
-    "RTIStatusResponse"
+    "RTIStatusResponse",
+    "RTIRequestHistoryResponse",
+    "RTIRequestHistoryListResponse"
 ]
 

--- a/tool/backend/src/models/response_models/rti_request_histories.py
+++ b/tool/backend/src/models/response_models/rti_request_histories.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from typing import Optional, List
+from uuid import UUID
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.models.common.common import PaginationModel
+from src.models.table_schemas import RTIDirection
+from .rti_statuses import RTIStatusShortResponse
+
+
+class RTIRequestHistoryResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+
+    id: UUID = Field(..., description="Unique identifier for the RTI Status History")
+    rti_request_id: UUID = Field(
+        ...,
+        serialization_alias="rtiRequestId",
+        description="Unique identifier for the associated RTI Request",
+    )
+    rti_status: RTIStatusShortResponse = Field(
+        ...,
+        serialization_alias="rtiStatus",
+        description="RTI Status object for this history entry",
+    )
+    direction: RTIDirection = Field(..., description="Direction of the RTI Status History (sent / received)")
+    description: Optional[str] = Field(None, description="Description for this history entry")
+    entry_time: datetime = Field(
+        ...,
+        serialization_alias="entryTime",
+        description="ISO 8601 timestamp when this status was entered",
+    )
+    exit_time: Optional[datetime] = Field(
+        None,
+        serialization_alias="exitTime",
+        description="ISO 8601 timestamp when this status was exited",
+    )
+    files: List[str] = Field([], description="List of file URLs attached to this history entry")
+    created_at: datetime = Field(
+        ...,
+        serialization_alias="createdAt",
+        description="ISO 8601 timestamp of when the history record was created",
+    )
+    updated_at: datetime = Field(
+        ...,
+        serialization_alias="updatedAt",
+        description="ISO 8601 timestamp of when the history record was last updated",
+    )
+
+
+class RTIRequestHistoryListResponse(BaseModel):
+    data: List[RTIRequestHistoryResponse] = Field(
+        [], description="List of RTI Request History records"
+    )
+    pagination: PaginationModel = Field(..., description="Pagination metadata")

--- a/tool/backend/src/models/response_models/rti_statuses.py
+++ b/tool/backend/src/models/response_models/rti_statuses.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import Sequence
 from src.models import PaginationModel
 
-
 class RTIStatusResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
     # attributes
@@ -26,10 +25,14 @@ class RTIStatusResponse(BaseModel):
         json_schema_extra={"example":"2026-03-31T09:00:00Z"},
         description="ISO 8601 timestamp of when the status was last updated",
     )
-
-
 class RTIStatusListResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
     # attributes
     data: Sequence[RTIStatusResponse] = Field([], description="List of statuses.")
     pagination: PaginationModel = Field(..., description="Pagination metadata.")
+
+class RTIStatusShortResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, str_strip_whitespace=True)
+
+    id: UUID = Field(..., description="Unique identifier for the RTI Status")
+    name: str = Field(..., description="Name of the RTI Status")

--- a/tool/backend/src/models/table_schemas/__init__.py
+++ b/tool/backend/src/models/table_schemas/__init__.py
@@ -1,4 +1,4 @@
-from .table_schemas import RTITemplate, Institution, Position, Sender, Receiver, RTIRequest, RTIStatus, RTIStatusHistories, RTIStatusName, RTIDirection
+from .table_schemas import RTITemplate, Institution, Position, Sender, Receiver, RTIRequest, RTIStatus, RTIStatusHistory, RTIStatusName, RTIDirection
 
 __all__ = [
     "RTITemplate",
@@ -8,7 +8,7 @@ __all__ = [
     "Receiver",
     "RTIRequest",
     "RTIStatus",
-    "RTIStatusHistories",
+    "RTIStatusHistory",
     "RTIStatusName",
     "RTIDirection"
 ]

--- a/tool/backend/src/models/table_schemas/__init__.py
+++ b/tool/backend/src/models/table_schemas/__init__.py
@@ -1,4 +1,4 @@
-from .table_schemas import RTITemplate, Institution, Position, Sender, Receiver, RTIRequest, RTIStatus, RTIStatusHistories, RTIStatusName
+from .table_schemas import RTITemplate, Institution, Position, Sender, Receiver, RTIRequest, RTIStatus, RTIStatusHistories, RTIStatusName, RTIDirection
 
 __all__ = [
     "RTITemplate",
@@ -9,6 +9,7 @@ __all__ = [
     "RTIRequest",
     "RTIStatus",
     "RTIStatusHistories",
-    "RTIStatusName"
+    "RTIStatusName",
+    "RTIDirection"
 ]
 

--- a/tool/backend/src/models/table_schemas/table_schemas.py
+++ b/tool/backend/src/models/table_schemas/table_schemas.py
@@ -159,7 +159,7 @@ class RTIRequest(SQLModel, table=True):
     sender: Sender = Relationship(back_populates="rti_requests")
     receiver: Receiver = Relationship(back_populates="rti_requests")
     rti_template: Optional[RTITemplate] = Relationship(back_populates="rti_requests")
-    rti_status_histories: List["RTIStatusHistories"] = Relationship(back_populates="rti_request")
+    rti_status_histories: List["RTIStatusHistory"] = Relationship(back_populates="rti_request")
 
 class RTIStatus(SQLModel, table=True):
     __tablename__ = "rti_statuses"
@@ -178,10 +178,10 @@ class RTIStatus(SQLModel, table=True):
     )
 
     # relationships
-    rti_status_histories: List["RTIStatusHistories"] = Relationship(back_populates="rti_status")
+    rti_status_histories: List["RTIStatusHistory"] = Relationship(back_populates="rti_status")
 
 
-class RTIStatusHistories(SQLModel, table=True):
+class RTIStatusHistory(SQLModel, table=True):
     __tablename__ = "rti_status_histories"
 
     # table fields

--- a/tool/backend/src/routers/__init__.py
+++ b/tool/backend/src/routers/__init__.py
@@ -5,6 +5,7 @@ from .sender_router import router as sender_router
 from .receiver_router import router as receiver_router
 from .rti_request_router import router as rti_request_router
 from .rti_status_router import router as rti_status_router
+from .rti_request_history_router import router as rti_request_history_router
 
 __all__ = [
     "rti_template_router",
@@ -13,5 +14,6 @@ __all__ = [
     "sender_router",
     "receiver_router",
     "rti_request_router",
-    "rti_status_router"
+    "rti_status_router",
+    "rti_request_history_router"
 ]

--- a/tool/backend/src/routers/rti_request_history_router.py
+++ b/tool/backend/src/routers/rti_request_history_router.py
@@ -1,7 +1,16 @@
 from uuid import UUID
-from typing import Annotated
-from fastapi import APIRouter, Query, Depends, Path
-from src.models import User, UserRole, RTIRequestHistoryListResponse
+from typing import Annotated, List, Optional
+from datetime import datetime
+from fastapi import APIRouter, Query, Depends, Path, Form, UploadFile, File
+
+from src.models import (
+    User, 
+    UserRole, 
+    RTIRequestHistoryListResponse, 
+    RTIRequestHistoryResponse,
+    RTIRequestHistoryRequest,
+    RTIDirection
+)
 from src.dependencies import RoleChecker
 from src.repositories.db import SessionDep
 from src.services import GithubFileService, RTIRequestHistoryService
@@ -31,4 +40,31 @@ async def get_rti_request_histories_endpoint(
         page_size=page_size,
     )
 
-    
+@router.post("/rti_requests/{id}/histories", response_model=RTIRequestHistoryResponse)
+async def create_rti_request_history_endpoint(
+    id: Annotated[UUID, Path(title="ID of the RTI Request")],
+    status_id: Annotated[UUID, Form(alias="statusId", description="ID of the RTI Status")],
+    direction: Annotated[RTIDirection, Form(description="Direction of the RTI Status History (sent / received)")],
+    entry_time: Annotated[Optional[datetime], Form(alias="entryTime", description="Entry time for the RTI Status History")] = None,
+    exit_time: Annotated[Optional[datetime], Form(alias="exitTime", description="Exit time for the RTI Status History")] = None,
+    description: Annotated[Optional[str], Form(description="Detailed description of the RTI Status History")] = None,
+    files: list[UploadFile | str] = File(None, description="List of files for the RTI Status History (pdf only)"),
+    service: RTIRequestHistoryService = Depends(get_rti_request_history_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER])),
+):
+    # Filter out empty strings
+    actual_files = [f for f in (files or []) if not isinstance(f, str)]
+
+    request_data = RTIRequestHistoryRequest(
+        statusId=status_id,
+        direction=direction,
+        entryTime=entry_time,
+        exitTime=exit_time,
+        description=description,
+        files=actual_files
+    )
+    return await service.create_rti_request_history(
+        rti_request_id=id,
+        request_data=request_data
+    )
+

--- a/tool/backend/src/routers/rti_request_history_router.py
+++ b/tool/backend/src/routers/rti_request_history_router.py
@@ -104,3 +104,17 @@ async def update_rti_request_history_endpoint(
         request_data=request_data
     )
 
+@router.delete("/rti_requests/{rti_id}/histories/{history_id}", status_code=204)
+async def delete_rti_request_history_endpoint(
+    rti_id: Annotated[UUID, Path(title="ID of the RTI Request")],
+    history_id: Annotated[UUID, Path(title="ID of the RTI Status History")],
+    service: RTIRequestHistoryService = Depends(get_rti_request_history_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER])),
+):
+    await service.delete_rti_request_history(
+        rti_request_id=rti_id,
+        history_id=history_id
+    )
+    return None
+
+

--- a/tool/backend/src/routers/rti_request_history_router.py
+++ b/tool/backend/src/routers/rti_request_history_router.py
@@ -1,0 +1,34 @@
+from uuid import UUID
+from typing import Annotated
+from fastapi import APIRouter, Query, Depends, Path
+from src.models import User, UserRole, RTIRequestHistoryListResponse
+from src.dependencies import RoleChecker
+from src.repositories.db import SessionDep
+from src.services import GithubFileService, RTIRequestHistoryService
+
+router = APIRouter(prefix="/api/v1", tags=["RTI-Requests"])
+
+def get_file_service() -> GithubFileService:
+    return GithubFileService()
+
+def get_rti_request_history_service(
+    session: SessionDep,
+    file_service: GithubFileService = Depends(get_file_service),
+) -> RTIRequestHistoryService:
+    return RTIRequestHistoryService(session, file_service)
+
+@router.get("/rti_requests/{id}/histories", response_model=RTIRequestHistoryListResponse)
+async def get_rti_request_histories_endpoint(
+    id: Annotated[UUID, Path(title="ID of the RTI Request")],
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(10, ge=1, le=100, alias="pageSize", description="Page size"),
+    service: RTIRequestHistoryService = Depends(get_rti_request_history_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER])),
+):
+    return service.get_rti_request_histories(
+        rti_request_id=id,
+        page=page,
+        page_size=page_size,
+    )
+
+    

--- a/tool/backend/src/routers/rti_request_history_router.py
+++ b/tool/backend/src/routers/rti_request_history_router.py
@@ -9,6 +9,7 @@ from src.models import (
     RTIRequestHistoryListResponse, 
     RTIRequestHistoryResponse,
     RTIRequestHistoryRequest,
+    RTIRequestHistoryUpdateRequest,
     RTIDirection
 )
 from src.dependencies import RoleChecker
@@ -65,6 +66,41 @@ async def create_rti_request_history_endpoint(
     )
     return await service.create_rti_request_history(
         rti_request_id=id,
+        request_data=request_data
+    )
+
+@router.put("/rti_requests/{rti_id}/histories/{history_id}", response_model=RTIRequestHistoryResponse)
+async def update_rti_request_history_endpoint(
+    rti_id: Annotated[UUID, Path(title="ID of the RTI Request")],
+    history_id: Annotated[UUID, Path(title="ID of the RTI Status History")],
+    status_id: Annotated[Optional[UUID], Form(alias="statusId", description="ID of the RTI Status")] = None,
+    direction: Annotated[Optional[RTIDirection], Form(description="Direction of the RTI Status History (sent / received)")] = None,
+    entry_time: Annotated[Optional[datetime], Form(alias="entryTime", description="Entry time for the RTI Status History")] = None,
+    exit_time: Annotated[Optional[datetime], Form(alias="exitTime", description="Exit time for the RTI Status History")] = None,
+    description: Annotated[Optional[str], Form(description="Detailed description of the RTI Status History")] = None,
+    files_to_add: list[UploadFile | str] = File(None, alias="filesToAdd", description="List of additional files to add (pdf only)"),
+    files_to_delete: list[str] = Form(None, alias="filesToDelete", description="List of file paths to delete"),
+    service: RTIRequestHistoryService = Depends(get_rti_request_history_service),
+    user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER])),
+):
+    # Filter out empty strings for filesToAdd
+    actual_files_to_add = [f for f in (files_to_add or []) if not isinstance(f, str)]
+    
+    # Filter out empty strings for filesToDelete
+    actual_files_to_delete = [f for f in (files_to_delete or []) if f and f.strip()]
+
+    request_data = RTIRequestHistoryUpdateRequest(
+        id=history_id,
+        statusId=status_id,
+        direction=direction,
+        entryTime=entry_time,
+        exitTime=exit_time,
+        description=description,
+        filesToAdd=actual_files_to_add,
+        filesToDelete=actual_files_to_delete
+    )
+    return await service.update_rti_request_history(
+        rti_request_id=rti_id,
         request_data=request_data
     )
 

--- a/tool/backend/src/services/__init__.py
+++ b/tool/backend/src/services/__init__.py
@@ -6,6 +6,7 @@ from .sender_service import SenderService
 from .receiver_service import ReceiverService
 from .rti_request_service import RTIRequestService
 from .rti_status_service import RTIStatusService
+from .rti_request_history_service import RTIRequestHistoryService
 
 __all__ = [
     "RTITemplateService",
@@ -15,7 +16,8 @@ __all__ = [
     "SenderService",
     "ReceiverService",
     "RTIRequestService",
-    "RTIStatusService"
+    "RTIStatusService",
+    "RTIRequestHistoryService"
 ]
 
 

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -10,7 +10,7 @@ from src.models import (
 from src.services.github_file_service import GithubFileService
 from src.models.table_schemas.table_schemas import (
     RTIRequest, 
-    RTIStatusHistories, 
+    RTIStatusHistory, 
     RTIStatus
 )
 from src.models.response_models.rti_request_histories import (
@@ -61,9 +61,9 @@ class RTIRequestHistoryService:
 
             # Fetch paginated history records ordered by created_at descending
             statement_records = (
-                select(RTIStatusHistories)
-                .where(RTIStatusHistories.rti_request_id == target_id)
-                .order_by(RTIStatusHistories.created_at.desc())
+                select(RTIStatusHistory)
+                .where(RTIStatusHistory.rti_request_id == target_id)
+                .order_by(RTIStatusHistory.created_at.desc())
                 .offset(offset)
                 .limit(page_size)
             )
@@ -72,8 +72,8 @@ class RTIRequestHistoryService:
             # Fetch total count
             statement_count = (
                 select(func.count())
-                .select_from(RTIStatusHistories)
-                .where(RTIStatusHistories.rti_request_id == target_id)
+                .select_from(RTIStatusHistory)
+                .where(RTIStatusHistory.rti_request_id == target_id)
             )
             total_items = self.session.exec(statement_count).one()
 
@@ -149,8 +149,8 @@ class RTIRequestHistoryService:
                         raise InternalServerException("[RTI HISTORY SERVICE] Invalid path response from file service")
                     
 
-            # 5. Insert RTIStatusHistories
-            status_history = RTIStatusHistories(
+            # 5. Insert RTIStatusHistory
+            status_history = RTIStatusHistory(
                 id=unique_history_id,
                 rti_request_id=rti_request_id,
                 status_id=request_data.status_id,
@@ -198,7 +198,7 @@ class RTIRequestHistoryService:
         uploaded_file_paths: list[str] = []
         try:
             target_id = request_data.id
-            history = self.session.get(RTIStatusHistories, target_id)
+            history = self.session.get(RTIStatusHistory, target_id)
             if not history:
                 raise NotFoundException(f"RTI Request History with id {target_id} not found.")
 
@@ -312,7 +312,7 @@ class RTIRequestHistoryService:
         committed = False
         files_to_delete: list[str] = []
         try:
-            history = self.session.get(RTIStatusHistories, history_id)
+            history = self.session.get(RTIStatusHistory, history_id)
             if not history:
                 raise NotFoundException(f"RTI Request History with id {history_id} not found.")
 

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -300,3 +300,47 @@ class RTIRequestHistoryService:
 
             logger.error(f"[RTI HISTORY SERVICE] Error updating history {request_data.id}: {e}")
             raise InternalServerException(f"Failed to update RTI request history: {e}") from e
+
+    # API
+    async def delete_rti_request_history(
+        self,
+        *,
+        rti_request_id: UUID,
+        history_id: UUID
+    ) -> None:
+        """Deletes an RTI Status History record and its associated files."""
+        committed = False
+        files_to_delete: list[str] = []
+        try:
+            history = self.session.get(RTIStatusHistories, history_id)
+            if not history:
+                raise NotFoundException(f"RTI Request History with id {history_id} not found.")
+
+            # Validation: Ensure the history record belongs to the specified RTI Request
+            if history.rti_request_id != rti_request_id:
+                raise BadRequestException(f"History record {history_id} does not belong to RTI Request {rti_request_id}")
+
+            files_to_delete = list(history.files) if history.files else []
+
+            self.session.delete(history)
+            self.session.commit()
+            committed = True
+
+            # Physically delete files from GitHub after successful DB commit
+            if files_to_delete:
+                for file_path in files_to_delete:
+                    try:
+                        await self.file_service.delete_file(file_path=file_path)
+                    except Exception as ex:
+                        # Log but don't fail, as the DB record is already gone
+                        logger.error(f"[RTI HISTORY SERVICE] Failed to delete orphaned file {file_path} from GitHub during record deletion: {ex}")
+
+        except (BadRequestException, NotFoundException, InternalServerException):
+            raise
+        except Exception as e:
+            if not committed:
+                self.session.rollback()
+
+            logger.error(f"[RTI HISTORY SERVICE] Error deleting history {history_id}: {e}")
+            raise InternalServerException(f"Failed to delete RTI request history: {e}") from e
+

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -5,6 +5,7 @@ from sqlmodel import Session, select, func
 from src.models import (
     PaginationModel,
     RTIRequestHistoryRequest,
+    RTIRequestHistoryUpdateRequest,
 )
 from src.services.github_file_service import GithubFileService
 from src.models.table_schemas.table_schemas import (
@@ -141,11 +142,12 @@ class RTIRequestHistoryService:
                         message=f"Upload file for RTI Request History {unique_history_id}"
                     )
                     
+                    uploaded_file_paths.append(file_path)
+                    
                     relative_path = response.get("relative_path", "")
                     if not relative_path:
                         raise InternalServerException("[RTI HISTORY SERVICE] Invalid path response from file service")
                     
-                    uploaded_file_paths.append(relative_path)
 
             # 5. Insert RTIStatusHistories
             status_history = RTIStatusHistories(
@@ -183,3 +185,118 @@ class RTIRequestHistoryService:
 
             logger.error(f"[RTI HISTORY SERVICE] Error creating history for RTI Request {rti_request_id}: {e}")
             raise InternalServerException(f"Failed to create RTI request history: {e}") from e
+
+    # API
+    async def update_rti_request_history(
+        self,
+        *,
+        rti_request_id: UUID,
+        request_data: RTIRequestHistoryUpdateRequest
+    ) -> RTIRequestHistoryResponse:
+        """Updates an existing RTI Status History record."""
+        committed = False
+        uploaded_file_paths: list[str] = []
+        try:
+            target_id = request_data.id
+            history = self.session.get(RTIStatusHistories, target_id)
+            if not history:
+                raise NotFoundException(f"RTI Request History with id {target_id} not found.")
+
+            # Validation: Ensure the history record belongs to the specified RTI Request
+            if history.rti_request_id != rti_request_id:
+                raise BadRequestException(f"History record {target_id} does not belong to RTI Request {rti_request_id}")
+
+            # Validate Status existence if provided
+            if request_data.status_id:
+                status = self.session.get(RTIStatus, request_data.status_id)
+                if not status:
+                    raise NotFoundException(f"RTI Status with id {request_data.status_id} not found.")
+                history.status_id = request_data.status_id
+
+            # Update other fields if provided
+            if request_data.direction:
+                history.direction = request_data.direction
+            if request_data.description is not None:
+                history.description = request_data.description
+            if request_data.entry_time:
+                history.entry_time = request_data.entry_time
+            if request_data.exit_time:
+                history.exit_time = request_data.exit_time
+
+            # Create a NEW list instance so SQLAlchemy detects the change to the JSON column
+            current_files = list(history.files) if history.files else []
+
+            # 1. Handle file deletions (from database list)
+            if request_data.files_to_delete:
+                for file_path in request_data.files_to_delete:
+                    if file_path in current_files:
+                        current_files.remove(file_path)
+                    else:
+                        logger.warning(f"[RTI HISTORY SERVICE] File {file_path} not found in history record {target_id}")
+
+            # 2. Handle new file uploads
+            if request_data.files_to_add:
+                # Validate extensions
+                for file in request_data.files_to_add:
+                    _, ext = os.path.splitext(file.filename)
+                    if not ext or ext.lower() not in self.ALLOWED_FILE_TYPES:
+                        raise BadRequestException(
+                            f"{file.filename} doesn't have a valid extension ({', '.join(self.ALLOWED_FILE_TYPES)})"
+                        )
+                
+                # Upload new files
+                base_idx = len(history.files)
+                for i, file in enumerate(request_data.files_to_add):
+                    _, ext = os.path.splitext(file.filename)
+                    file_path = f"rti-requests/{history.rti_request_id}/histories/{target_id}/{target_id}_u{base_idx + i}{ext.lower()}"
+                    
+                    content = await file.read()
+                    response = await self.file_service.create_file(
+                        file_path=file_path,
+                        content=content,
+                        message=f"Upload additional file for RTI Request History {target_id}"
+                    )
+                    
+                    uploaded_file_paths.append(file_path)
+
+                    relative_path = response.get("relative_path", "")
+                    if not relative_path:
+                        raise InternalServerException("[RTI HISTORY SERVICE] Invalid path response from file service")
+                    
+                    current_files.append(relative_path)
+
+            history.files = current_files
+            self.session.add(history)
+            self.session.commit()
+            committed = True
+
+            # 3. Handle physical file deletions from GitHub after successful commit
+            if request_data.files_to_delete:
+                for file_path in request_data.files_to_delete:
+                    try:
+                        await self.file_service.delete_file(file_path=file_path)
+                    except Exception as ex:
+                        # Log but don't fail, as the DB is already updated
+                        logger.error(f"[RTI HISTORY SERVICE] Failed to delete orphaned file {file_path} from GitHub: {ex}")
+
+            self.session.refresh(history)
+            return RTIRequestHistoryResponse.model_validate(history)
+
+        except (BadRequestException, NotFoundException, ConflictException, InternalServerException):
+            raise
+        except Exception as e:
+            if not committed:
+                self.session.rollback()
+                # Clean up newly uploaded files if DB update failed
+                for file_path in uploaded_file_paths:
+                    try:
+                        await self.file_service.delete_file(file_path=file_path)
+                    except Exception as ex:
+                        logger.error(f"[RTI HISTORY SERVICE] Rollback failed - could not delete {file_path}: {ex}")
+
+            if isinstance(e, IntegrityError):
+                logger.error(f"[RTI HISTORY SERVICE] Integrity error updating history: {e}")
+                raise ConflictException("Database integrity error occurred while updating the RTI Request History.") from e
+
+            logger.error(f"[RTI HISTORY SERVICE] Error updating history {request_data.id}: {e}")
+            raise InternalServerException(f"Failed to update RTI request history: {e}") from e

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -231,10 +231,12 @@ class RTIRequestHistoryService:
             current_files = list(history.files) if history.files else []
 
             # 1. Handle file deletions (from database list)
+            actual_deleted_files = []
             if request_data.files_to_delete:
                 for file_path in request_data.files_to_delete:
                     if file_path in current_files:
                         current_files.remove(file_path)
+                        actual_deleted_files.append(file_path)
                     else:
                         logger.warning(f"[RTI HISTORY SERVICE] File {file_path} not found in history record {target_id}")
 
@@ -276,8 +278,8 @@ class RTIRequestHistoryService:
             committed = True
 
             # 3. Handle physical file deletions from GitHub after successful commit
-            if request_data.files_to_delete:
-                for file_path in request_data.files_to_delete:
+            if actual_deleted_files:
+                for file_path in actual_deleted_files:
                     try:
                         await self.file_service.delete_file(file_path=file_path)
                     except Exception as ex:

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -1,8 +1,6 @@
 import logging
 from uuid import UUID
-
 from sqlmodel import Session, select, func
-
 from src.models import PaginationModel
 from src.services.github_file_service import GithubFileService
 from src.models.table_schemas.table_schemas import RTIRequest, RTIStatusHistories
@@ -13,7 +11,6 @@ from src.models.response_models.rti_request_histories import (
 from src.core.exceptions import InternalServerException, NotFoundException, BadRequestException
 
 logger = logging.getLogger(__name__)
-
 
 class RTIRequestHistoryService:
     """
@@ -34,7 +31,6 @@ class RTIRequestHistoryService:
         page: int = 1,
         page_size: int = 10,
     ) -> RTIRequestHistoryListResponse:
-        """Fetches a paginated list of RTI Status History records for a given RTI Request."""
         try:
             # Validate that the parent RTI Request exists
             try:
@@ -48,11 +44,11 @@ class RTIRequestHistoryService:
 
             offset = (page - 1) * page_size
 
-            # Fetch paginated history records ordered by entry_time ascending
+            # Fetch paginated history records ordered by created_at descending
             statement_records = (
                 select(RTIStatusHistories)
                 .where(RTIStatusHistories.rti_request_id == target_id)
-                .order_by(RTIStatusHistories.entry_time.asc())
+                .order_by(RTIStatusHistories.created_at.desc())
                 .offset(offset)
                 .limit(page_size)
             )

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -24,6 +24,7 @@ from src.core.exceptions import (
     ConflictException
 )
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,7 @@ class RTIRequestHistoryService:
             statement_records = (
                 select(RTIStatusHistory)
                 .where(RTIStatusHistory.rti_request_id == target_id)
+                .options(selectinload(RTIStatusHistory.rti_status))
                 .order_by(RTIStatusHistory.created_at.desc())
                 .offset(offset)
                 .limit(page_size)
@@ -139,14 +141,16 @@ class RTIRequestHistoryService:
                     response = await self.file_service.create_file(
                         file_path=file_path,
                         content=content,
-                        message=f"Upload file for RTI Request History {unique_history_id}"
+                        message=f"Upload file for RTI Request History {unique_history_id}_{i}{ext.lower()}"
                     )
-                    
-                    uploaded_file_paths.append(file_path)
                     
                     relative_path = response.get("relative_path", "")
                     if not relative_path:
+                        # If service returned success but no path, attempt immediate cleanup of the target path
+                        await self.file_service.delete_file(file_path=file_path)
                         raise InternalServerException("[RTI HISTORY SERVICE] Invalid path response from file service")
+                    
+                    uploaded_file_paths.append(relative_path)
                     
 
             # 5. Insert RTIStatusHistory
@@ -248,7 +252,7 @@ class RTIRequestHistoryService:
                 base_idx = len(history.files) if history.files else 0
                 for i, file in enumerate(request_data.files_to_add):
                     _, ext = os.path.splitext(file.filename)
-                    file_path = f"rti-requests/{history.rti_request_id}/histories/{target_id}/{target_id}_u{base_idx + i}{ext.lower()}"
+                    file_path = f"rti-requests/{history.rti_request_id}/histories/{target_id}/{target_id}_{base_idx + i}{ext.lower()}"
                     
                     content = await file.read()
                     response = await self.file_service.create_file(
@@ -257,12 +261,13 @@ class RTIRequestHistoryService:
                         message=f"Upload additional file for RTI Request History {target_id}"
                     )
                     
-                    uploaded_file_paths.append(file_path)
-
                     relative_path = response.get("relative_path", "")
                     if not relative_path:
+                        # Attempt immediate cleanup of the target path if response is invalid
+                        await self.file_service.delete_file(file_path=file_path)
                         raise InternalServerException("[RTI HISTORY SERVICE] Invalid path response from file service")
                     
+                    uploaded_file_paths.append(relative_path)
                     current_files.append(relative_path)
 
             history.files = current_files

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -1,14 +1,28 @@
+import os
 import logging
-from uuid import UUID
+from uuid import UUID, uuid4
 from sqlmodel import Session, select, func
-from src.models import PaginationModel
+from src.models import (
+    PaginationModel,
+    RTIRequestHistoryRequest,
+)
 from src.services.github_file_service import GithubFileService
-from src.models.table_schemas.table_schemas import RTIRequest, RTIStatusHistories
+from src.models.table_schemas.table_schemas import (
+    RTIRequest, 
+    RTIStatusHistories, 
+    RTIStatus
+)
 from src.models.response_models.rti_request_histories import (
     RTIRequestHistoryResponse,
     RTIRequestHistoryListResponse,
 )
-from src.core.exceptions import InternalServerException, NotFoundException, BadRequestException
+from src.core.exceptions import (
+    InternalServerException, 
+    NotFoundException, 
+    BadRequestException,
+    ConflictException
+)
+from sqlalchemy.exc import IntegrityError
 
 logger = logging.getLogger(__name__)
 
@@ -81,3 +95,91 @@ class RTIRequestHistoryService:
             raise InternalServerException(
                 "Failed to fetch RTI request histories from database."
             ) from e
+
+    # API
+    async def create_rti_request_history(
+        self,
+        *,
+        rti_request_id: UUID,
+        request_data: RTIRequestHistoryRequest
+    ) -> RTIRequestHistoryResponse:
+
+        committed = False
+        uploaded_file_paths: list[str] = []
+        try:
+            # 1. Validate RTI Request existence
+            rti_request = self.session.get(RTIRequest, rti_request_id)
+            if not rti_request:
+                raise NotFoundException(f"RTI Request with id {rti_request_id} not found.")
+
+            # 2. Validate Status existence
+            status = self.session.get(RTIStatus, request_data.status_id)
+            if not status:
+                raise NotFoundException(f"RTI Status with id {request_data.status_id} not found.")
+
+            # 3. Validate files
+            if request_data.files:
+                for file in request_data.files:
+                    _, ext = os.path.splitext(file.filename)
+                    if not ext or ext.lower() not in self.ALLOWED_FILE_TYPES:
+                        raise BadRequestException(
+                            f"{file.filename} doesn't have a valid extension ({', '.join(self.ALLOWED_FILE_TYPES)})"
+                        )
+
+            unique_history_id = uuid4()
+            
+            # 4. Upload files to GitHub
+            if request_data.files:
+                for i, file in enumerate(request_data.files):
+                    _, ext = os.path.splitext(file.filename)
+                    file_path = f"rti-requests/{rti_request_id}/histories/{unique_history_id}/{unique_history_id}_{i}{ext.lower()}"
+                    
+                    content = await file.read()
+                    response = await self.file_service.create_file(
+                        file_path=file_path,
+                        content=content,
+                        message=f"Upload file for RTI Request History {unique_history_id}"
+                    )
+                    
+                    relative_path = response.get("relative_path", "")
+                    if not relative_path:
+                        raise InternalServerException("[RTI HISTORY SERVICE] Invalid path response from file service")
+                    
+                    uploaded_file_paths.append(relative_path)
+
+            # 5. Insert RTIStatusHistories
+            status_history = RTIStatusHistories(
+                id=unique_history_id,
+                rti_request_id=rti_request_id,
+                status_id=request_data.status_id,
+                direction=request_data.direction,
+                description=request_data.description,
+                entry_time=request_data.entry_time,
+                exit_time=request_data.exit_time,
+                files=uploaded_file_paths
+            )
+            self.session.add(status_history)
+            self.session.commit()
+            committed = True
+            self.session.refresh(status_history)
+
+            return RTIRequestHistoryResponse.model_validate(status_history)
+
+        except (BadRequestException, NotFoundException, ConflictException, InternalServerException):
+            raise
+        except Exception as e:
+            if not committed:
+                self.session.rollback()
+                # Compensating transaction: remove uploaded files from GitHub
+                for file_path in uploaded_file_paths:
+                    try:
+                        await self.file_service.delete_file(file_path=file_path)
+                    except Exception as ex:
+                        logger.error(f"[RTI HISTORY SERVICE] Rollback failed - could not delete {file_path}: {ex}")
+
+            if isinstance(e, IntegrityError):
+                logger.error(f"[RTI HISTORY SERVICE] Integrity error creating history: {e}")
+                raise ConflictException("Database integrity error occurred while creating the RTI Request History.") from e
+
+            logger.error(f"[RTI HISTORY SERVICE] Error creating history for RTI Request {rti_request_id}: {e}")
+            raise InternalServerException(f"Failed to create RTI request history: {e}") from e

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -39,7 +39,7 @@ class RTIRequestHistoryService:
         self.file_service = file_service
 
     # API
-    def get_rti_request_histories(
+    def get_rti_request_histories_by_id(
         self,
         *,
         rti_request_id: UUID,

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -184,7 +184,7 @@ class RTIRequestHistoryService:
                 raise ConflictException("Database integrity error occurred while creating the RTI Request History.") from e
 
             logger.error(f"[RTI HISTORY SERVICE] Error creating history for RTI Request {rti_request_id}: {e}")
-            raise InternalServerException(f"Failed to create RTI request history: {e}") from e
+            raise InternalServerException(f"Failed to create RTI request history.") from e
 
     # API
     async def update_rti_request_history(
@@ -207,20 +207,20 @@ class RTIRequestHistoryService:
                 raise BadRequestException(f"History record {target_id} does not belong to RTI Request {rti_request_id}")
 
             # Validate Status existence if provided
-            if request_data.status_id:
+            if request_data.status_id is not None:
                 status = self.session.get(RTIStatus, request_data.status_id)
                 if not status:
                     raise NotFoundException(f"RTI Status with id {request_data.status_id} not found.")
                 history.status_id = request_data.status_id
 
             # Update other fields if provided
-            if request_data.direction:
+            if request_data.direction is not None:
                 history.direction = request_data.direction
             if request_data.description is not None:
                 history.description = request_data.description
-            if request_data.entry_time:
+            if request_data.entry_time is not None:
                 history.entry_time = request_data.entry_time
-            if request_data.exit_time:
+            if request_data.exit_time is not None:
                 history.exit_time = request_data.exit_time
 
             # Create a NEW list instance so SQLAlchemy detects the change to the JSON column
@@ -245,7 +245,7 @@ class RTIRequestHistoryService:
                         )
                 
                 # Upload new files
-                base_idx = len(history.files)
+                base_idx = len(history.files) if history.files else 0
                 for i, file in enumerate(request_data.files_to_add):
                     _, ext = os.path.splitext(file.filename)
                     file_path = f"rti-requests/{history.rti_request_id}/histories/{target_id}/{target_id}_u{base_idx + i}{ext.lower()}"

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -1,0 +1,87 @@
+import logging
+from uuid import UUID
+
+from sqlmodel import Session, select, func
+
+from src.models import PaginationModel
+from src.services.github_file_service import GithubFileService
+from src.models.table_schemas.table_schemas import RTIRequest, RTIStatusHistories
+from src.models.response_models.rti_request_histories import (
+    RTIRequestHistoryResponse,
+    RTIRequestHistoryListResponse,
+)
+from src.core.exceptions import InternalServerException, NotFoundException, BadRequestException
+
+logger = logging.getLogger(__name__)
+
+
+class RTIRequestHistoryService:
+    """
+    This service is responsible for executing all RTI request history operations.
+    """
+
+    ALLOWED_FILE_TYPES = [".pdf"]
+
+    def __init__(self, session: Session, file_service: GithubFileService):
+        self.session = session
+        self.file_service = file_service
+
+    # API
+    def get_rti_request_histories(
+        self,
+        *,
+        rti_request_id: UUID,
+        page: int = 1,
+        page_size: int = 10,
+    ) -> RTIRequestHistoryListResponse:
+        """Fetches a paginated list of RTI Status History records for a given RTI Request."""
+        try:
+            # Validate that the parent RTI Request exists
+            try:
+                target_id = UUID(str(rti_request_id))
+            except ValueError:
+                raise BadRequestException(f"Invalid UUID format: {rti_request_id}")
+
+            rti_request = self.session.get(RTIRequest, target_id)
+            if not rti_request:
+                raise NotFoundException(f"RTI Request with id {rti_request_id} not found.")
+
+            offset = (page - 1) * page_size
+
+            # Fetch paginated history records ordered by entry_time ascending
+            statement_records = (
+                select(RTIStatusHistories)
+                .where(RTIStatusHistories.rti_request_id == target_id)
+                .order_by(RTIStatusHistories.entry_time.asc())
+                .offset(offset)
+                .limit(page_size)
+            )
+            results = self.session.exec(statement_records).all()
+
+            # Fetch total count
+            statement_count = (
+                select(func.count())
+                .select_from(RTIStatusHistories)
+                .where(RTIStatusHistories.rti_request_id == target_id)
+            )
+            total_items = self.session.exec(statement_count).one()
+
+            pagination = PaginationModel(
+                page=page,
+                page_size=page_size,
+                total_items=total_items,
+                total_pages=(total_items + page_size - 1) // page_size if total_items > 0 else 0,
+            )
+
+            return RTIRequestHistoryListResponse(
+                data=[RTIRequestHistoryResponse.model_validate(r) for r in results],
+                pagination=pagination,
+            )
+
+        except (BadRequestException, NotFoundException):
+            raise
+        except Exception as e:
+            logger.error(f"[RTI HISTORY SERVICE] Error fetching histories for RTI Request {rti_request_id}: {e}")
+            raise InternalServerException(
+                "Failed to fetch RTI request histories from database."
+            ) from e

--- a/tool/backend/src/services/rti_request_service.py
+++ b/tool/backend/src/services/rti_request_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import select, Session, func
 from src.models import PaginationModel
 from src.services.github_file_service import GithubFileService
-from src.models.table_schemas.table_schemas import RTIRequest, RTIStatus, RTIStatusHistories, RTIDirection, Receiver, Sender, RTITemplate, RTIStatusName
+from src.models.table_schemas.table_schemas import RTIRequest, RTIStatus, RTIStatusHistory, RTIDirection, Receiver, Sender, RTITemplate, RTIStatusName
 from src.models.response_models.rti_requests import RTIRequestResponse, RTIRequestListResponse
 from src.models.request_models.rti_requests import RTIRequestRequest, RTIRequestUpdateRequest
 from src.core.exceptions import InternalServerException, BadRequestException, NotFoundException, ConflictException
@@ -77,14 +77,14 @@ class RTIRequestService:
             )
             self.session.add(rti_request)
 
-            # 4. Insert RTIStatusHistories
+            # 4. Insert RTIStatusHistory
             statement = select(RTIStatus).where(RTIStatus.name == RTIStatusName.CREATED)
             created_status = self.session.exec(statement).first()
 
             if not created_status:
                 raise InternalServerException("Status 'CREATED' not found in database.")
 
-            status_history = RTIStatusHistories(
+            status_history = RTIStatusHistory(
                 id=uuid4(),
                 rti_request_id=unique_id,
                 status_id=created_status.id,
@@ -200,7 +200,7 @@ class RTIRequestService:
                 raise NotFoundException(f"RTI Request with id {target_id} not found.")
 
             # Check if request has progressed
-            statement_histories = select(RTIStatusHistories).where(RTIStatusHistories.rti_request_id == target_id)
+            statement_histories = select(RTIStatusHistory).where(RTIStatusHistory.rti_request_id == target_id)
             histories = self.session.exec(statement_histories).all()
             if len(histories) > 1:
                 raise ConflictException("Cannot update RTI Request because it has associated status history records beyond creation.")
@@ -231,9 +231,9 @@ class RTIRequestService:
                 if not created_status:
                     raise InternalServerException("Status 'CREATED' not found in database.")
 
-                history_statement = select(RTIStatusHistories).where(
-                    RTIStatusHistories.rti_request_id == target_id,
-                    RTIStatusHistories.status_id == created_status.id
+                history_statement = select(RTIStatusHistory).where(
+                    RTIStatusHistory.rti_request_id == target_id,
+                    RTIStatusHistory.status_id == created_status.id
                 )
                 status_history = self.session.exec(history_statement).first()
 
@@ -334,7 +334,7 @@ class RTIRequestService:
                 raise NotFoundException(f"RTI Request with id {target_id} not found.")
 
             # 1. Fetch all histories and their files
-            statement = select(RTIStatusHistories).where(RTIStatusHistories.rti_request_id == target_id)
+            statement = select(RTIStatusHistory).where(RTIStatusHistory.rti_request_id == target_id)
             histories = self.session.exec(statement).all()
             
             # If there are more than 1 history record, it means the request has progressed

--- a/tool/backend/src/services/rti_request_service.py
+++ b/tool/backend/src/services/rti_request_service.py
@@ -62,6 +62,7 @@ class RTIRequestService:
 
             relative_path = response.get("relative_path", "")
             if not relative_path:
+                await self.file_service.delete_file(file_path=file_path)
                 raise InternalServerException("[RTI SERVICE] Invalid path response from file service")
 
             uploaded_file_path = relative_path
@@ -263,6 +264,13 @@ class RTIRequestService:
                         content=new_file_content,
                         message=f"Update file (new extension) for RTI Request {target_id}"
                     )
+
+                    relative_path = response.get("relative_path", "")
+                    if not relative_path:
+                        await self.file_service.delete_file(file_path=new_file_path)
+                        raise InternalServerException("[RTI SERVICE] Invalid path response from file service")
+
+                    new_file_path = relative_path
                     status_history.files = [new_file_path]
                     self.session.add(status_history)
 

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -4,7 +4,7 @@ import uuid
 from aiohttp import ClientError
 from datetime import datetime, timezone, timedelta
 from sqlmodel import SQLModel, Session, create_engine
-from src.models import RTITemplate, Institution, Position, Receiver, ReceiverRequest, ReceiverUpdateRequest, RTIRequest, RTIStatus, RTIStatusHistories, RTIStatusName
+from src.models import RTITemplate, Institution, Position, Receiver, ReceiverRequest, ReceiverUpdateRequest, RTIRequest, RTIStatus, RTIStatusHistory, RTIStatusName
 from src.models.request_models import RTITemplateRequest, PositionRequest
 from src.services.github_file_service import GithubFileService
 from fastapi import UploadFile

--- a/tool/backend/test/test_rti_request_history_service.py
+++ b/tool/backend/test/test_rti_request_history_service.py
@@ -583,5 +583,188 @@ async def test_delete_rti_request_history_db_failure(rti_request_db, make_file_s
     # Verify GitHub deletion was NOT called
     fs.delete_file.assert_not_called()
 
+@pytest.mark.asyncio
+async def test_update_rti_request_history_status_not_found(rti_request_db, make_file_service):
+    """NotFoundException raised when updating history with a non-existent status ID."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    history = RTIStatusHistory(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc)
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    request = RTIRequestHistoryUpdateRequest(id=history.id, statusId=uuid.uuid4())
+    
+    with pytest.raises(NotFoundException) as exc:
+        await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    assert "RTI Status" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_update_rti_request_history_invalid_file_extension(rti_request_db, make_file_service, make_upload_file):
+    """BadRequestException raised when adding files with unsupported extensions during update."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    history = RTIStatusHistory(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc)
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    request = RTIRequestHistoryUpdateRequest(
+        id=history.id,
+        filesToAdd=[make_upload_file(filename="malicious.exe")]
+    )
+    
+    with pytest.raises(BadRequestException) as exc:
+        await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    assert "valid extension" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_update_rti_request_history_invalid_relative_path_response(rti_request_db, make_file_service, make_upload_file):
+    """InternalServerException raised and cleanup triggered if file service returns empty relative_path."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    history = RTIStatusHistory(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc),
+        files=[]
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    fs = make_file_service()
+    # Mock create_file to return success but with empty relative_path
+    fs.create_file = AsyncMock(return_value={"relative_path": ""})
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    request = RTIRequestHistoryUpdateRequest(
+        id=history.id,
+        filesToAdd=[make_upload_file(filename="test.pdf")]
+    )
+    
+    with pytest.raises(InternalServerException) as exc:
+        await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    assert "Invalid path response" in str(exc.value)
+    
+    # Verify cleanup was attempted for the calculated path
+    cleanup_path = fs.create_file.call_args.kwargs['file_path']
+    fs.delete_file.assert_called_once_with(file_path=cleanup_path)
+
+@pytest.mark.asyncio
+async def test_update_rti_request_history_files_to_delete_missing_path(rti_request_db, make_file_service):
+    """Update still succeeds if a non-existent path is provided in filesToDelete."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    existing_file = "rti-requests/exists.pdf"
+    history = RTIStatusHistory(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc),
+        files=[existing_file]
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    fs = make_file_service()
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    # "non-existent.pdf" is not in history.files
+    request = RTIRequestHistoryUpdateRequest(
+        id=history.id,
+        filesToDelete=["non-existent.pdf", existing_file]
+    )
+    
+    response = await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    
+    # existing_file should be deleted, non-existent should be ignored
+    assert response.files == []
+    fs.delete_file.assert_called_once_with(file_path=existing_file)
+
+@pytest.mark.asyncio
+async def test_update_rti_request_history_file_upload_exception(rti_request_db, make_file_service, make_upload_file):
+    """InternalServerException raised and DB rolled back if file service throws during update."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    history = RTIStatusHistory(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc)
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    fs = make_file_service()
+    fs.create_file = AsyncMock(side_effect=Exception("Upload Failed"))
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    request = RTIRequestHistoryUpdateRequest(
+        id=history.id,
+        description="Should fail",
+        filesToAdd=[make_upload_file(filename="test.pdf")]
+    )
+    
+    with pytest.raises(InternalServerException):
+        await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    
+    # Verify DB was not updated (description should still be original or None)
+    rti_request_db.rollback() # Ensure session is clean
+    db_history = rti_request_db.get(RTIStatusHistory, history.id)
+    assert db_history.description is None
+
+@pytest.mark.asyncio
+async def test_delete_rti_request_history_github_delete_failure_post_commit(rti_request_db, make_file_service):
+    """API succeeds even if GitHub file deletion fails after the DB commit during record deletion."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    file_path = "rti-requests/orphan.pdf"
+    history = RTIStatusHistory(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc),
+        files=[file_path]
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    fs = make_file_service()
+    # Mock delete_file to fail
+    fs.delete_file = AsyncMock(side_effect=Exception("GitHub Down"))
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    # Should not raise exception because DB delete happened first
+    await service.delete_rti_request_history(rti_request_id=rti_request.id, history_id=history.id)
+    
+    # DB record should be gone
+    assert rti_request_db.get(RTIStatusHistory, history.id) is None
+    fs.delete_file.assert_called_once_with(file_path=file_path)
+
 
 

--- a/tool/backend/test/test_rti_request_history_service.py
+++ b/tool/backend/test/test_rti_request_history_service.py
@@ -237,11 +237,8 @@ async def test_create_rti_request_history_db_failure_rolls_back_files(rti_reques
     with pytest.raises(InternalServerException):
         await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
     
-    # Get the actual path that was passed to create_file
-    uploaded_path = fs.create_file.call_args.kwargs['file_path']
-    
-    # Verify file service delete was called with that same path
-    fs.delete_file.assert_called_once_with(file_path=uploaded_path)
+    # Verify file service delete was called with the relative_path returned by create_file
+    fs.delete_file.assert_called_once_with(file_path="to-be-deleted.pdf")
 
 
 @pytest.mark.asyncio
@@ -486,12 +483,8 @@ async def test_update_rti_request_history_db_failure_rolls_back_new_files(rti_re
     with pytest.raises(InternalServerException):
         await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
     
-    # Capture the actual path that was used for the new upload
-    new_upload_path = fs.create_file.call_args.kwargs['file_path']
-    
-    # Verify file service delete was called ONLY for the new file
-    # The existing file should NOT be deleted because the commit failed
-    fs.delete_file.assert_called_once_with(file_path=new_upload_path)
+    # Verify file service delete was called ONLY for the new file (using its relative_path)
+    fs.delete_file.assert_called_once_with(file_path="orphaned.pdf")
     
     # Double check that delete_file was NOT called for the existing_file
     for call in fs.delete_file.call_args_list:

--- a/tool/backend/test/test_rti_request_history_service.py
+++ b/tool/backend/test/test_rti_request_history_service.py
@@ -498,4 +498,97 @@ async def test_update_rti_request_history_db_failure_rolls_back_new_files(rti_re
         assert call.kwargs['file_path'] != existing_file
 
 
+@pytest.mark.asyncio
+async def test_delete_rti_request_history_success(rti_request_db, make_file_service):
+    """Deleting a history record successfully cleans up DB and GitHub files."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    file_path = "rti-requests/to-be-nuked.pdf"
+    history = RTIStatusHistories(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc),
+        files=[file_path]
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    fs = make_file_service()
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    await service.delete_rti_request_history(rti_request_id=rti_request.id, history_id=history.id)
+    
+    # Verify DB record is gone
+    deleted_history = rti_request_db.get(RTIStatusHistories, history.id)
+    assert deleted_history is None
+    
+    # Verify GitHub deletion was called
+    fs.delete_file.assert_called_once_with(file_path=file_path)
+
+@pytest.mark.asyncio
+async def test_delete_rti_request_history_wrong_rti(rti_request_db, make_file_service):
+    """Fails when attempting to delete a history record via the wrong RTI Request."""
+    rti_request1 = create_test_rti_request(rti_request_db)
+    rti_request2 = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    history = RTIStatusHistories(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request1.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc)
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    with pytest.raises(BadRequestException) as exc:
+        await service.delete_rti_request_history(rti_request_id=rti_request2.id, history_id=history.id)
+    assert "does not belong to RTI Request" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_delete_rti_request_history_not_found(rti_request_db, make_file_service):
+    """Fails when deleting a non-existent history record."""
+    rti_request = create_test_rti_request(rti_request_db)
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    with pytest.raises(NotFoundException):
+        await service.delete_rti_request_history(rti_request_id=rti_request.id, history_id=uuid.uuid4())
+
+@pytest.mark.asyncio
+async def test_delete_rti_request_history_db_failure(rti_request_db, make_file_service, monkeypatch):
+    """GitHub files are NOT deleted if DB record deletion fails."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    file_path = "rti-requests/safe.pdf"
+    history = RTIStatusHistories(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc),
+        files=[file_path]
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    # Mock commit failure
+    monkeypatch.setattr(rti_request_db, "commit", MagicMock(side_effect=Exception("DB Failure")))
+    
+    fs = make_file_service()
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    with pytest.raises(InternalServerException):
+        await service.delete_rti_request_history(rti_request_id=rti_request.id, history_id=history.id)
+    
+    # Verify GitHub deletion was NOT called
+    fs.delete_file.assert_not_called()
+
+
 

--- a/tool/backend/test/test_rti_request_history_service.py
+++ b/tool/backend/test/test_rti_request_history_service.py
@@ -1,8 +1,8 @@
 # test/test_rti_request_history_service.py
 import uuid
 import pytest
-from unittest.mock import MagicMock
-from sqlalchemy.exc import OperationalError
+from unittest.mock import MagicMock, AsyncMock
+from sqlalchemy.exc import OperationalError, IntegrityError
 from sqlmodel import select, Session, create_engine, SQLModel
 from datetime import datetime, timezone, timedelta
 
@@ -13,8 +13,9 @@ from src.models.table_schemas.table_schemas import (
 from src.models.response_models.rti_request_histories import (
     RTIRequestHistoryResponse, RTIRequestHistoryListResponse
 )
+from src.models.request_models.rti_request_histories import RTIRequestHistoryRequest
 from src.core.exceptions import (
-    InternalServerException, BadRequestException, NotFoundException
+    InternalServerException, BadRequestException, NotFoundException, ConflictException
 )
 
 def create_test_rti_request(session: Session):
@@ -117,3 +118,205 @@ async def test_get_rti_request_histories_internal_error(rti_request_db, monkeypa
     with pytest.raises(InternalServerException) as exc:
         service.get_rti_request_histories(rti_request_id=rti_request.id)
     assert "Failed to fetch RTI request histories" in str(exc.value)
+
+
+# test create rti request history
+@pytest.mark.asyncio
+async def test_create_rti_request_history_success(rti_request_db, make_file_service, make_upload_file):
+    """Happy path: RTI Request History is created with files, entry_time and exit_time."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    fs = make_file_service(relative_path="rti-requests/hist/123.pdf")
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    now = datetime.now(timezone.utc)
+    entry_time = now - timedelta(hours=1)
+    exit_time = now
+    
+    files = [make_upload_file(filename="doc1.pdf"), make_upload_file(filename="doc2.pdf")]
+    
+    request = RTIRequestHistoryRequest(
+        statusId=status.id,
+        direction=RTIDirection.received,
+        description="Response received",
+        entryTime=entry_time,
+        exitTime=exit_time,
+        files=files
+    )
+    
+    result = await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    
+    assert isinstance(result, RTIRequestHistoryResponse)
+    assert result.description == "Response received"
+    assert result.direction == RTIDirection.received
+    assert result.rti_status.id == status.id
+    assert len(result.files) == 2
+    
+    # Normalize datetimes for comparison
+    assert result.entry_time.replace(tzinfo=timezone.utc) == entry_time.replace(tzinfo=timezone.utc)
+    assert result.exit_time.replace(tzinfo=timezone.utc) == exit_time.replace(tzinfo=timezone.utc)
+    
+    # Verify file service was called twice
+    assert fs.create_file.call_count == 2
+
+@pytest.mark.asyncio
+async def test_create_rti_request_history_request_not_found(rti_request_db, make_file_service):
+    """NotFoundException raised when parent RTI Request doesn't exist."""
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    request = RTIRequestHistoryRequest(
+        statusId=status.id,
+        direction=RTIDirection.sent,
+        entryTime=datetime.now(timezone.utc)
+    )
+    
+    with pytest.raises(NotFoundException) as exc:
+        await service.create_rti_request_history(rti_request_id=uuid.uuid4(), request_data=request)
+    assert "RTI Request" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_create_rti_request_history_status_not_found(rti_request_db, make_file_service):
+    """NotFoundException raised when provided RTI Status ID doesn't exist."""
+    rti_request = create_test_rti_request(rti_request_db)
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    request = RTIRequestHistoryRequest(
+        statusId=uuid.uuid4(),
+        direction=RTIDirection.sent,
+        entryTime=datetime.now(timezone.utc)
+    )
+    
+    with pytest.raises(NotFoundException) as exc:
+        await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    assert "RTI Status" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_create_rti_request_history_invalid_file_extension(rti_request_db, make_file_service, make_upload_file):
+    """BadRequestException raised for unsupported file extensions."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    files = [make_upload_file(filename="malicious.exe")]
+    
+    request = RTIRequestHistoryRequest(
+        statusId=status.id,
+        direction=RTIDirection.sent,
+        entryTime=datetime.now(timezone.utc),
+        files=files
+    )
+    
+    with pytest.raises(BadRequestException) as exc:
+        await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    assert "valid extension" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_create_rti_request_history_db_failure_rolls_back_files(rti_request_db, monkeypatch, make_file_service, make_upload_file):
+    """Verifies that uploaded files are deleted from GitHub if DB commit fails."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    fs = make_file_service(relative_path="to-be-deleted.pdf")
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    # Mock commit failure
+    monkeypatch.setattr(rti_request_db, "commit", MagicMock(side_effect=Exception("DB Error")))
+    
+    request = RTIRequestHistoryRequest(
+        statusId=status.id,
+        direction=RTIDirection.sent,
+        entryTime=datetime.now(timezone.utc),
+        files=[make_upload_file(filename="test.pdf")]
+    )
+    
+    with pytest.raises(InternalServerException):
+        await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    
+    # Verify file service delete was called
+    fs.delete_file.assert_called_once_with(file_path="to-be-deleted.pdf")
+
+@pytest.mark.asyncio
+async def test_create_rti_request_history_without_files(rti_request_db, make_file_service):
+    """Creating history without files is successful."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    request = RTIRequestHistoryRequest(
+        statusId=status.id,
+        direction=RTIDirection.sent,
+        entryTime=datetime.now(timezone.utc),
+        files=[]
+    )
+    
+    result = await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    assert result.files == []
+
+@pytest.mark.asyncio
+async def test_create_rti_request_history_default_entry_time(rti_request_db, make_file_service):
+    """entry_time defaults to current time if not provided in the request."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    # Passing None for entryTime (Pydantic validator should fill it)
+    request = RTIRequestHistoryRequest(
+        statusId=status.id,
+        direction=RTIDirection.sent,
+        entryTime=None,
+        files=[]
+    )
+    
+    result = await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    assert result.entry_time is not None
+    assert isinstance(result.entry_time, datetime)
+    # Check if it's close to now
+    assert (datetime.now(timezone.utc) - result.entry_time.replace(tzinfo=timezone.utc)).total_seconds() < 5
+
+@pytest.mark.asyncio
+async def test_create_rti_request_history_integrity_error(rti_request_db, monkeypatch, make_file_service):
+    """ConflictException raised on database integrity error (e.g. duplicate UUID)."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    # Mock commit to raise IntegrityError
+    monkeypatch.setattr(rti_request_db, "commit", MagicMock(side_effect=IntegrityError("Conflict", None, None)))
+    
+    request = RTIRequestHistoryRequest(
+        statusId=status.id,
+        direction=RTIDirection.sent,
+        entryTime=datetime.now(timezone.utc),
+        files=[]
+    )
+    
+    with pytest.raises(ConflictException) as exc:
+        await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    assert "integrity error" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_create_rti_request_history_file_upload_failure(rti_request_db, make_file_service, make_upload_file):
+    """InternalServerException raised if file service fails during upload."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    # Mock file service to raise exception on create_file
+    fs = make_file_service()
+    fs.create_file = AsyncMock(side_effect=Exception("Upload Failed"))
+    
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    request = RTIRequestHistoryRequest(
+        statusId=status.id,
+        direction=RTIDirection.sent,
+        entryTime=datetime.now(timezone.utc),
+        files=[make_upload_file(filename="test.pdf")]
+    )
+    
+    with pytest.raises(InternalServerException) as exc:
+        await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    assert "Failed to create RTI request history" in str(exc.value)
+
+

--- a/tool/backend/test/test_rti_request_history_service.py
+++ b/tool/backend/test/test_rti_request_history_service.py
@@ -13,7 +13,10 @@ from src.models.table_schemas.table_schemas import (
 from src.models.response_models.rti_request_histories import (
     RTIRequestHistoryResponse, RTIRequestHistoryListResponse
 )
-from src.models.request_models.rti_request_histories import RTIRequestHistoryRequest
+from src.models.request_models.rti_request_histories import (
+    RTIRequestHistoryRequest, 
+    RTIRequestHistoryUpdateRequest
+)
 from src.core.exceptions import (
     InternalServerException, BadRequestException, NotFoundException, ConflictException
 )
@@ -322,5 +325,177 @@ async def test_create_rti_request_history_file_upload_failure(rti_request_db, ma
     with pytest.raises(InternalServerException) as exc:
         await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
     assert "Failed to create RTI request history" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_update_rti_request_history_success(rti_request_db, make_file_service):
+    """Updating basic fields of a history record is successful."""
+    rti_request = create_test_rti_request(rti_request_db)
+    
+    # Ensure at least two statuses exist
+    status_list = rti_request_db.exec(select(RTIStatus)).all()
+    if len(status_list) < 2:
+        status2 = RTIStatus(id=uuid.uuid4(), name="Status 2", description="Second status")
+        rti_request_db.add(status2)
+        rti_request_db.commit()
+        status_list = rti_request_db.exec(select(RTIStatus)).all()
+        
+    status1 = status_list[0]
+    status2 = status_list[1]
+
+    
+    # Create initial history
+    history = RTIStatusHistories(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status1.id,
+        direction=RTIDirection.sent,
+        description="Initial",
+        entry_time=datetime.now(timezone.utc)
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    new_entry_time = datetime.now(timezone.utc) + timedelta(hours=1)
+    new_exit_time = datetime.now(timezone.utc) + timedelta(hours=2)
+    
+    request = RTIRequestHistoryUpdateRequest(
+        id=history.id,
+        statusId=status2.id,
+        direction=RTIDirection.received,
+        description="Updated",
+        entryTime=new_entry_time,
+        exitTime=new_exit_time
+    )
+    
+    response = await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    
+    assert response.id == history.id
+    assert response.rti_status.id == status2.id
+    assert response.direction == RTIDirection.received
+
+    assert response.description == "Updated"
+    assert response.entry_time.replace(tzinfo=timezone.utc).timestamp() == pytest.approx(new_entry_time.replace(tzinfo=timezone.utc).timestamp(), abs=1)
+    assert response.exit_time.replace(tzinfo=timezone.utc).timestamp() == pytest.approx(new_exit_time.replace(tzinfo=timezone.utc).timestamp(), abs=1)
+
+
+@pytest.mark.asyncio
+async def test_update_rti_request_history_add_delete_files(rti_request_db, make_file_service, make_upload_file, monkeypatch):
+    """Adding new files and deleting existing ones works correctly."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    existing_file = "rti-requests/old-file.pdf"
+    history = RTIStatusHistories(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc),
+        files=[existing_file]
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    fs = make_file_service(relative_path="new-file.pdf")
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    request = RTIRequestHistoryUpdateRequest(
+        id=history.id,
+        filesToAdd=[make_upload_file(filename="test.pdf")],
+        filesToDelete=[existing_file]
+    )
+    
+    response = await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    
+    # Check DB updated
+    assert len(response.files) == 1
+    assert "new-file.pdf" in response.files
+    assert existing_file not in response.files
+    
+    # Check physical deletion from GitHub was called
+    fs.delete_file.assert_called_with(file_path=existing_file)
+
+@pytest.mark.asyncio
+async def test_update_rti_request_history_wrong_rti_request(rti_request_db, make_file_service):
+    """Attempting to update a history record via the wrong RTI Request fails."""
+    rti_request1 = create_test_rti_request(rti_request_db)
+    rti_request2 = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    history = RTIStatusHistories(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request1.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc)
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    request = RTIRequestHistoryUpdateRequest(id=history.id, description="Try to steal")
+    
+    with pytest.raises(BadRequestException) as exc:
+        await service.update_rti_request_history(rti_request_id=rti_request2.id, request_data=request)
+    assert "does not belong to RTI Request" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_update_rti_request_history_not_found(rti_request_db, make_file_service):
+    """Updating a non-existent history record fails."""
+    rti_request = create_test_rti_request(rti_request_db)
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    request = RTIRequestHistoryUpdateRequest(id=uuid.uuid4(), description="Missing")
+    
+    with pytest.raises(NotFoundException):
+        await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+
+@pytest.mark.asyncio
+async def test_update_rti_request_history_db_failure_rolls_back_new_files(rti_request_db, make_file_service, make_upload_file, monkeypatch):
+    """If DB commit fails during update, new files are cleaned up but old files stay safe."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    existing_file = "rti-requests/stay-safe.pdf"
+    history = RTIStatusHistories(
+        id=uuid.uuid4(),
+        rti_request_id=rti_request.id,
+        status_id=status.id,
+        direction=RTIDirection.sent,
+        entry_time=datetime.now(timezone.utc),
+        files=[existing_file]
+    )
+    rti_request_db.add(history)
+    rti_request_db.commit()
+    
+    fs = make_file_service(relative_path="orphaned.pdf")
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+    
+    # Mock commit failure
+    monkeypatch.setattr(rti_request_db, "commit", MagicMock(side_effect=Exception("DB Failure")))
+    
+    request = RTIRequestHistoryUpdateRequest(
+        id=history.id,
+        filesToAdd=[make_upload_file(filename="new.pdf")],
+        filesToDelete=[existing_file]
+    )
+    
+    with pytest.raises(InternalServerException):
+        await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    
+    # Capture the actual path that was used for the new upload
+    new_upload_path = fs.create_file.call_args.kwargs['file_path']
+    
+    # Verify file service delete was called ONLY for the new file
+    # The existing file should NOT be deleted because the commit failed
+    fs.delete_file.assert_called_once_with(file_path=new_upload_path)
+    
+    # Double check that delete_file was NOT called for the existing_file
+    for call in fs.delete_file.call_args_list:
+        assert call.kwargs['file_path'] != existing_file
+
 
 

--- a/tool/backend/test/test_rti_request_history_service.py
+++ b/tool/backend/test/test_rti_request_history_service.py
@@ -65,7 +65,7 @@ async def test_get_rti_request_histories_success(rti_request_db, make_file_servi
     service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
     
     # 3. Fetch with page_size=2
-    response = service.get_rti_request_histories(rti_request_id=rti_request.id, page=1, page_size=2)
+    response = service.get_rti_request_histories_by_id(rti_request_id=rti_request.id, page=1, page_size=2)
     
     # 4. Assertions
     assert isinstance(response, RTIRequestHistoryListResponse)
@@ -82,7 +82,7 @@ async def test_get_rti_request_histories_not_found(rti_request_db, make_file_ser
     service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
     
     with pytest.raises(NotFoundException) as exc:
-        service.get_rti_request_histories(rti_request_id=uuid.uuid4())
+        service.get_rti_request_histories_by_id(rti_request_id=uuid.uuid4())
     assert "not found" in str(exc.value)
 
 @pytest.mark.asyncio
@@ -91,7 +91,7 @@ async def test_get_rti_request_histories_invalid_uuid(rti_request_db, make_file_
     service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
     
     with pytest.raises(BadRequestException) as exc:
-        service.get_rti_request_histories(rti_request_id="not-a-uuid")
+        service.get_rti_request_histories_by_id(rti_request_id="not-a-uuid")
     assert "Invalid UUID format" in str(exc.value)
 
 @pytest.mark.asyncio
@@ -101,7 +101,7 @@ async def test_get_rti_request_histories_empty(rti_request_db, make_file_service
     rti_request = create_test_rti_request(rti_request_db)
     
     service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
-    response = service.get_rti_request_histories(rti_request_id=rti_request.id)
+    response = service.get_rti_request_histories_by_id(rti_request_id=rti_request.id)
     
     assert response.data == []
     assert response.pagination.total_items == 0
@@ -119,7 +119,7 @@ async def test_get_rti_request_histories_internal_error(rti_request_db, monkeypa
     monkeypatch.setattr(rti_request_db, "exec", fake_exec)
     
     with pytest.raises(InternalServerException) as exc:
-        service.get_rti_request_histories(rti_request_id=rti_request.id)
+        service.get_rti_request_histories_by_id(rti_request_id=rti_request.id)
     assert "Failed to fetch RTI request histories" in str(exc.value)
 
 

--- a/tool/backend/test/test_rti_request_history_service.py
+++ b/tool/backend/test/test_rti_request_history_service.py
@@ -234,8 +234,12 @@ async def test_create_rti_request_history_db_failure_rolls_back_files(rti_reques
     with pytest.raises(InternalServerException):
         await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
     
-    # Verify file service delete was called
-    fs.delete_file.assert_called_once_with(file_path="to-be-deleted.pdf")
+    # Get the actual path that was passed to create_file
+    uploaded_path = fs.create_file.call_args.kwargs['file_path']
+    
+    # Verify file service delete was called with that same path
+    fs.delete_file.assert_called_once_with(file_path=uploaded_path)
+
 
 @pytest.mark.asyncio
 async def test_create_rti_request_history_without_files(rti_request_db, make_file_service):

--- a/tool/backend/test/test_rti_request_history_service.py
+++ b/tool/backend/test/test_rti_request_history_service.py
@@ -1,0 +1,119 @@
+# test/test_rti_request_history_service.py
+import uuid
+import pytest
+from unittest.mock import MagicMock
+from sqlalchemy.exc import OperationalError
+from sqlmodel import select, Session, create_engine, SQLModel
+from datetime import datetime, timezone, timedelta
+
+from src.services.rti_request_history_service import RTIRequestHistoryService
+from src.models.table_schemas.table_schemas import (
+    RTIRequest, RTIStatusHistories, RTIDirection, RTIStatus, Sender, Receiver
+)
+from src.models.response_models.rti_request_histories import (
+    RTIRequestHistoryResponse, RTIRequestHistoryListResponse
+)
+from src.core.exceptions import (
+    InternalServerException, BadRequestException, NotFoundException
+)
+
+def create_test_rti_request(session: Session):
+    """Helper to seed an RTIRequest since rti_request_db fixture doesn't seed one."""
+    sender = session.exec(select(Sender)).first()
+    receiver = session.exec(select(Receiver)).first()
+    rti_request = RTIRequest(
+        id=uuid.uuid4(),
+        title="Test RTI Request",
+        sender_id=sender.id,
+        receiver_id=receiver.id,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+    session.add(rti_request)
+    session.commit()
+    session.refresh(rti_request)
+    return rti_request
+
+# test get rti request histories
+@pytest.mark.asyncio
+async def test_get_rti_request_histories_success(rti_request_db, make_file_service):
+    """Happy path: Fetches paginated history records for a valid RTI Request."""
+    # 1. Setup - Seed RTI Request and Status
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    
+    # 2. Add history records (3 records)
+    now = datetime.now(timezone.utc)
+    histories = [
+        RTIStatusHistories(
+            id=uuid.uuid4(),
+            rti_request_id=rti_request.id,
+            status_id=status.id,
+            direction=RTIDirection.sent,
+            description=f"History {i}",
+            entry_time=now + timedelta(minutes=i),
+            files=[f"file{i}.pdf"]
+        ) for i in range(3)
+    ]
+    rti_request_db.add_all(histories)
+    rti_request_db.commit()
+    
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    # 3. Fetch with page_size=2
+    response = service.get_rti_request_histories(rti_request_id=rti_request.id, page=1, page_size=2)
+    
+    # 4. Assertions
+    assert isinstance(response, RTIRequestHistoryListResponse)
+    assert len(response.data) == 2
+    assert response.pagination.total_items == 3
+    assert response.pagination.total_pages == 2
+    assert response.data[0].description == "History 2"
+    assert response.data[1].description == "History 1"
+    assert isinstance(response.data[0], RTIRequestHistoryResponse)
+
+@pytest.mark.asyncio
+async def test_get_rti_request_histories_not_found(rti_request_db, make_file_service):
+    """NotFoundException raised when RTI Request ID doesn't exist."""
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    with pytest.raises(NotFoundException) as exc:
+        service.get_rti_request_histories(rti_request_id=uuid.uuid4())
+    assert "not found" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_get_rti_request_histories_invalid_uuid(rti_request_db, make_file_service):
+    """BadRequestException raised for invalid UUID format."""
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    with pytest.raises(BadRequestException) as exc:
+        service.get_rti_request_histories(rti_request_id="not-a-uuid")
+    assert "Invalid UUID format" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_get_rti_request_histories_empty(rti_request_db, make_file_service):
+    """Returns empty list and zero total items when no history exists for a valid request."""
+    # Seed a new request without history
+    rti_request = create_test_rti_request(rti_request_db)
+    
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    response = service.get_rti_request_histories(rti_request_id=rti_request.id)
+    
+    assert response.data == []
+    assert response.pagination.total_items == 0
+
+@pytest.mark.asyncio
+async def test_get_rti_request_histories_internal_error(rti_request_db, monkeypatch, make_file_service):
+    """InternalServerException raised on database failure during retrieval."""
+    rti_request = create_test_rti_request(rti_request_db)
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+    
+    # Mock session.exec to raise an exception
+    def fake_exec(*args, **kwargs):
+        raise OperationalError("Fake DB failure", None, None)
+    
+    monkeypatch.setattr(rti_request_db, "exec", fake_exec)
+    
+    with pytest.raises(InternalServerException) as exc:
+        service.get_rti_request_histories(rti_request_id=rti_request.id)
+    assert "Failed to fetch RTI request histories" in str(exc.value)

--- a/tool/backend/test/test_rti_request_history_service.py
+++ b/tool/backend/test/test_rti_request_history_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone, timedelta
 
 from src.services.rti_request_history_service import RTIRequestHistoryService
 from src.models.table_schemas.table_schemas import (
-    RTIRequest, RTIStatusHistories, RTIDirection, RTIStatus, Sender, Receiver
+    RTIRequest, RTIStatusHistory, RTIDirection, RTIStatus, Sender, Receiver
 )
 from src.models.response_models.rti_request_histories import (
     RTIRequestHistoryResponse, RTIRequestHistoryListResponse
@@ -49,7 +49,7 @@ async def test_get_rti_request_histories_success(rti_request_db, make_file_servi
     # 2. Add history records (3 records)
     now = datetime.now(timezone.utc)
     histories = [
-        RTIStatusHistories(
+        RTIStatusHistory(
             id=uuid.uuid4(),
             rti_request_id=rti_request.id,
             status_id=status.id,
@@ -344,7 +344,7 @@ async def test_update_rti_request_history_success(rti_request_db, make_file_serv
 
     
     # Create initial history
-    history = RTIStatusHistories(
+    history = RTIStatusHistory(
         id=uuid.uuid4(),
         rti_request_id=rti_request.id,
         status_id=status1.id,
@@ -387,7 +387,7 @@ async def test_update_rti_request_history_add_delete_files(rti_request_db, make_
     status = rti_request_db.exec(select(RTIStatus)).first()
     
     existing_file = "rti-requests/old-file.pdf"
-    history = RTIStatusHistories(
+    history = RTIStatusHistory(
         id=uuid.uuid4(),
         rti_request_id=rti_request.id,
         status_id=status.id,
@@ -424,7 +424,7 @@ async def test_update_rti_request_history_wrong_rti_request(rti_request_db, make
     rti_request2 = create_test_rti_request(rti_request_db)
     status = rti_request_db.exec(select(RTIStatus)).first()
     
-    history = RTIStatusHistories(
+    history = RTIStatusHistory(
         id=uuid.uuid4(),
         rti_request_id=rti_request1.id,
         status_id=status.id,
@@ -460,7 +460,7 @@ async def test_update_rti_request_history_db_failure_rolls_back_new_files(rti_re
     status = rti_request_db.exec(select(RTIStatus)).first()
     
     existing_file = "rti-requests/stay-safe.pdf"
-    history = RTIStatusHistories(
+    history = RTIStatusHistory(
         id=uuid.uuid4(),
         rti_request_id=rti_request.id,
         status_id=status.id,
@@ -505,7 +505,7 @@ async def test_delete_rti_request_history_success(rti_request_db, make_file_serv
     status = rti_request_db.exec(select(RTIStatus)).first()
     
     file_path = "rti-requests/to-be-nuked.pdf"
-    history = RTIStatusHistories(
+    history = RTIStatusHistory(
         id=uuid.uuid4(),
         rti_request_id=rti_request.id,
         status_id=status.id,
@@ -522,7 +522,7 @@ async def test_delete_rti_request_history_success(rti_request_db, make_file_serv
     await service.delete_rti_request_history(rti_request_id=rti_request.id, history_id=history.id)
     
     # Verify DB record is gone
-    deleted_history = rti_request_db.get(RTIStatusHistories, history.id)
+    deleted_history = rti_request_db.get(RTIStatusHistory, history.id)
     assert deleted_history is None
     
     # Verify GitHub deletion was called
@@ -535,7 +535,7 @@ async def test_delete_rti_request_history_wrong_rti(rti_request_db, make_file_se
     rti_request2 = create_test_rti_request(rti_request_db)
     status = rti_request_db.exec(select(RTIStatus)).first()
     
-    history = RTIStatusHistories(
+    history = RTIStatusHistory(
         id=uuid.uuid4(),
         rti_request_id=rti_request1.id,
         status_id=status.id,
@@ -567,7 +567,7 @@ async def test_delete_rti_request_history_db_failure(rti_request_db, make_file_s
     status = rti_request_db.exec(select(RTIStatus)).first()
     
     file_path = "rti-requests/safe.pdf"
-    history = RTIStatusHistories(
+    history = RTIStatusHistory(
         id=uuid.uuid4(),
         rti_request_id=rti_request.id,
         status_id=status.id,

--- a/tool/backend/test/test_rti_request_service.py
+++ b/tool/backend/test/test_rti_request_service.py
@@ -410,7 +410,9 @@ async def test_update_rti_request_post_commit_file_deletion_failure(rti_request_
     sender = rti_request_db.exec(select(Sender)).first()
     receiver = rti_request_db.exec(select(Receiver)).first()
     
-    fs = make_file_service()
+    initial_path = "rti-requests/old-file.pdf"
+    updated_path = "rti-requests/new-file.txt"
+    fs = make_file_service(relative_path=initial_path)
     fs.read_file = AsyncMock(return_value={"content": b"old", "sha": "sha"})
     # Fail ONLY the delete_file call
     fs.delete_file = AsyncMock(side_effect=Exception("GitHub Down"))
@@ -420,6 +422,9 @@ async def test_update_rti_request_post_commit_file_deletion_failure(rti_request_
     # Create with .pdf
     request = make_rti_request_request(sender_id=sender.id, receiver_id=receiver.id, filename="old.pdf")
     created = await service.create_rti_request(request_data=request)
+    
+    # Change the mock to return a .txt path for the next create_file call (during update)
+    fs.create_file = AsyncMock(return_value={"relative_path": updated_path})
     
     # To trigger delete_file, we'd need another allowed extension.
     # We modify it temporarily and ENSURE it is restored to prevent isolation leaks.
@@ -433,15 +438,14 @@ async def test_update_rti_request_post_commit_file_deletion_failure(rti_request_
         result = await service.update_rti_request(request_data=update_request)
         
         assert result.id == created.id
-        fs.delete_file.assert_called_once()
+        fs.delete_file.assert_called_once_with(file_path=initial_path)
         
         # CRITICAL: Verify that the DB was actually updated despite the cleanup failure
         # Get the history record for the CREATED status
         status_history = rti_request_db.exec(
             select(RTIStatusHistory).where(RTIStatusHistory.rti_request_id == created.id)
         ).first()
-        expected_path = f"rti-requests/{created.id}/{created.id}.txt"
-        assert status_history.files == [expected_path]
+        assert status_history.files == [updated_path]
     finally:
         service.ALLOWED_FILE_TYPES = original_types
 

--- a/tool/backend/test/test_rti_request_service.py
+++ b/tool/backend/test/test_rti_request_service.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 
 from src.services.rti_request_service import RTIRequestService
 from src.models.table_schemas.table_schemas import (
-    RTIRequest, RTIStatus, RTIStatusHistories, RTIDirection, 
+    RTIRequest, RTIStatus, RTIStatusHistory, RTIDirection, 
     Sender, Receiver, RTITemplate
 )
 from src.models.response_models.rti_requests import RTIRequestResponse
@@ -45,8 +45,8 @@ async def test_create_rti_request_success(rti_request_db, make_file_service, mak
     db_request = rti_request_db.exec(select(RTIRequest).where(RTIRequest.id == result.id)).first()
     assert db_request is not None
     
-    # Check if RTIStatusHistories record exists
-    db_history = rti_request_db.exec(select(RTIStatusHistories).where(RTIStatusHistories.rti_request_id == result.id)).first()
+    # Check if RTIStatusHistory record exists
+    db_history = rti_request_db.exec(select(RTIStatusHistory).where(RTIStatusHistory.rti_request_id == result.id)).first()
     assert db_history is not None
     assert db_history.direction == RTIDirection.sent
     assert db_history.files == ["rti-requests/dir/file.pdf"]
@@ -438,7 +438,7 @@ async def test_update_rti_request_post_commit_file_deletion_failure(rti_request_
         # CRITICAL: Verify that the DB was actually updated despite the cleanup failure
         # Get the history record for the CREATED status
         status_history = rti_request_db.exec(
-            select(RTIStatusHistories).where(RTIStatusHistories.rti_request_id == created.id)
+            select(RTIStatusHistory).where(RTIStatusHistory.rti_request_id == created.id)
         ).first()
         expected_path = f"rti-requests/{created.id}/{created.id}.txt"
         assert status_history.files == [expected_path]
@@ -456,7 +456,7 @@ async def test_update_rti_request_missing_initial_history(rti_request_db, make_f
     created = await service.create_rti_request(request_data=request)
     
     # Delete the history record
-    histories = rti_request_db.exec(select(RTIStatusHistories).where(RTIStatusHistories.rti_request_id == created.id)).all()
+    histories = rti_request_db.exec(select(RTIStatusHistory).where(RTIStatusHistory.rti_request_id == created.id)).all()
     for h in histories:
         rti_request_db.delete(h)
     rti_request_db.commit()
@@ -495,7 +495,7 @@ async def test_update_rti_request_blocked_by_history(rti_request_db, make_file_s
     status = rti_request_db.exec(select(RTIStatus)).first()
         
     # Add second history
-    history2 = RTIStatusHistories(
+    history2 = RTIStatusHistory(
         id=uuid.uuid4(),
         rti_request_id=created.id,
         status_id=status.id,
@@ -604,7 +604,7 @@ async def test_delete_rti_request_success(rti_request_db, make_file_service, mak
     assert rti_request_db.get(RTIRequest, created.id) is None
     
     # Verify History deletion
-    histories = rti_request_db.exec(select(RTIStatusHistories).where(RTIStatusHistories.rti_request_id == created.id)).all()
+    histories = rti_request_db.exec(select(RTIStatusHistory).where(RTIStatusHistory.rti_request_id == created.id)).all()
     assert len(histories) == 0
     
     # Verify GitHub deletion
@@ -653,7 +653,7 @@ async def test_delete_rti_request_blocked_by_history(rti_request_db, make_file_s
     created = await service.create_rti_request(request_data=request)
     
     # Add a second history record
-    history2 = RTIStatusHistories(
+    history2 = RTIStatusHistory(
         id=uuid.uuid4(),
         rti_request_id=created.id,
         status_id=rti_request_db.exec(select(RTIStatus)).first().id, # just use any status


### PR DESCRIPTION
## Overview
This PR introduces four new API endpoints that enables **rti request histories** create, update, deletion and read. 

**New API endpoint:**
`GET /rti_requests/{id}/histories`
`POST /rti_requests/{id}/histories`
`PUT /rti_requests/{rti_id}/histories/{history_id}`
`DELETE /rti_requests/{rti_id}/histories/{history_id}`

---

## Changes
* **Routing:** Added new routers to the `rti_request_history_router.py` file.
* **Service Layer:** Developed the services in the `rti_request_service.py` file.
* **Testing:** Added new test cases to cover the service functionalities.

---

## Testing
* **Service Tests:** Updated `test_rti_request_history_service.py` with new test cases to cover the new endpoint.
* **Mocks:** Updated `conftest.py` with new mock services.
* **Status:** All tests are passing.

---

## Additional Information
This PR Closes #103 