### PR TITLE
Bug: Update the response of the each deletion endpoints

### DIFF
--- a/tool/backend/src/routers/institution_router.py
+++ b/tool/backend/src/routers/institution_router.py
@@ -7,7 +7,7 @@ from src.repositories.db import SessionDep
 from src.models.response_models import InstitutionListResponse, InstitutionResponse
 from src.dependencies import RoleChecker
 from src.models import UserRole, User
-from fastapi import Depends, Query, status
+from fastapi import Depends, Query, status, Response, APIRouter
 from fastapi.routing import APIRouter
 
 router = APIRouter(prefix="/api/v1", tags=["Institutions"])
@@ -60,5 +60,5 @@ def delete_institution_endpoint(
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     service.delete_institution(institution_id=institution_id)
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/tool/backend/src/routers/position_router.py
+++ b/tool/backend/src/routers/position_router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query, status, Path
+from fastapi import APIRouter, Depends, Query, status, Path, Response
 from typing_extensions import Annotated
 from src.services import PositionService
 from src.repositories.db import SessionDep
@@ -48,11 +48,12 @@ def update_position_put_endpoint(
 ):
     return service.update_position_put(position_id=position_id, position_request=position_request)
 
-@router.delete("/positions/{position_id}", response_model=None, status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/positions/{position_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_position_endpoint(
     position_id: Annotated[UUID, Path(title="ID of the position")],
     service: PositionService = Depends(get_position_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
-    return service.delete_position(position_id=position_id)
+    service.delete_position(position_id=position_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
     

--- a/tool/backend/src/routers/receiver_router.py
+++ b/tool/backend/src/routers/receiver_router.py
@@ -3,7 +3,7 @@ from src.repositories.db import SessionDep
 from src.models import User, UserRole, ReceiverRequest, ReceiverUpdateRequest
 from src.dependencies import RoleChecker
 from src.models.response_models import ReceiverListResponse, ReceiverResponse
-from fastapi import APIRouter, Query, Depends, Path, status
+from fastapi import APIRouter, Query, Depends, Path, status, Response
 from uuid import UUID
 from typing_extensions import Annotated
 
@@ -54,5 +54,5 @@ def delete_receiver_endpoint(
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     service.delete_receiver(receiver_id=receiver_id)
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/tool/backend/src/routers/rti_request_history_router.py
+++ b/tool/backend/src/routers/rti_request_history_router.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 from typing import Annotated, List, Optional
 from datetime import datetime
-from fastapi import APIRouter, Query, Depends, Path, Form, UploadFile, File
+from fastapi import APIRouter, Query, Depends, Path, Form, UploadFile, File, status, Response
 
 from src.models import (
     User, 
@@ -104,7 +104,7 @@ async def update_rti_request_history_endpoint(
         request_data=request_data
     )
 
-@router.delete("/rti_requests/{rti_id}/histories/{history_id}", status_code=204)
+@router.delete("/rti_requests/{rti_id}/histories/{history_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_rti_request_history_endpoint(
     rti_id: Annotated[UUID, Path(title="ID of the RTI Request")],
     history_id: Annotated[UUID, Path(title="ID of the RTI Status History")],
@@ -115,6 +115,6 @@ async def delete_rti_request_history_endpoint(
         rti_request_id=rti_id,
         history_id=history_id
     )
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/tool/backend/src/routers/rti_request_router.py
+++ b/tool/backend/src/routers/rti_request_router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Form, UploadFile, File, Query, Path
+from fastapi import APIRouter, Depends, Form, UploadFile, File, Query, Path, status, Response
 from typing import Annotated, Optional
 from uuid import UUID
 
@@ -81,13 +81,13 @@ async def update_rti_request_endpoint(
     response = await service.update_rti_request(request_data=request_data)
     return response
 
-@router.delete("/rti_requests/{id}", status_code=204)
+@router.delete("/rti_requests/{id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_rti_request_endpoint(
     id: Annotated[UUID, Path(title="ID of the RTI Request")],
     service: RTIRequestService = Depends(get_rti_request_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     await service.delete_rti_request(request_id=id)
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     

--- a/tool/backend/src/routers/rti_status_router.py
+++ b/tool/backend/src/routers/rti_status_router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query, status, Path
+from fastapi import APIRouter, Depends, Query, status, Path, Response
 from typing_extensions import Annotated
 from src.services import RTIStatusService
 from src.repositories.db import SessionDep
@@ -46,13 +46,14 @@ def update_rti_status_put_endpoint(
 ):
     return service.update_rti_status_put(rti_status_id=id, rti_status_request=rti_status_request)
 
-@router.delete("/rti_statuses/{id}", response_model=None, status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/rti_statuses/{id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_rti_status_endpoint(
     id: Annotated[UUID, Path(title="ID of the RTI status")],
     service: RTIStatusService = Depends(get_rti_status_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
-    return service.delete_rti_status(rti_status_id=id)
+    service.delete_rti_status(rti_status_id=id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 

--- a/tool/backend/src/routers/rti_template_router.py
+++ b/tool/backend/src/routers/rti_template_router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query, Form, UploadFile, File, Path, status
+from fastapi import APIRouter, Depends, Query, Form, UploadFile, File, Path, status, Response
 from typing import Annotated, Optional
 from src.services import RTITemplateService, GithubFileService
 from src.repositories.db import SessionDep
@@ -65,7 +65,7 @@ async def delete_rti_template_endpoint(
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
     await service.delete_rti_template(template_id=id)
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 

--- a/tool/backend/src/routers/sender_router.py
+++ b/tool/backend/src/routers/sender_router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query, status, Path
+from fastapi import APIRouter, Depends, Query, status, Path, Response
 from typing_extensions import Annotated
 from src.services import SenderService
 from src.repositories.db import SessionDep
@@ -46,13 +46,14 @@ def update_sender_put_endpoint(
 ):
     return service.update_sender_put(sender_id=sender_id, sender_request=sender_request)
 
-@router.delete("/senders/{sender_id}", response_model=None, status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/senders/{sender_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_sender_endpoint(
     sender_id: Annotated[UUID, Path(title="ID of the sender")],
     service: SenderService = Depends(get_sender_service),
     user: User = Depends(RoleChecker([UserRole.ADMIN, UserRole.USER]))
 ):
-    return service.delete_sender(sender_id=sender_id)
+    service.delete_sender(sender_id=sender_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -32,7 +32,7 @@ class RTITemplateService:
             offset = (page - 1) * page_size
 
             # fetch the records from the table
-            statement_records = select(RTITemplate).offset(offset).limit(page_size)
+            statement_records = select(RTITemplate).order_by(RTITemplate.created_at.desc()).offset(offset).limit(page_size)
             results = self.session.exec(statement_records).all()
             
             # fetch the total record count


### PR DESCRIPTION
Currently the deletion endpoints return `None` with the `Content-Type` : `application/json` which is harder to http client SDK to catch and identify the response status. This PR includes the fix for that. 
- Now each DELETE endpoint returns `Response()` instance with `content=None` and `headers=None`.
- Added missing `order_by` orm key in the rti template list retrieval endpoint