### PR TITLE
refactor: centralize file validation rules

### DIFF
--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from uuid import UUID, uuid4
 from sqlmodel import Session, select, func

--- a/tool/backend/src/services/rti_request_history_service.py
+++ b/tool/backend/src/services/rti_request_history_service.py
@@ -25,6 +25,10 @@ from src.core.exceptions import (
 )
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
+from src.utils.file_validation import (
+    FileValidationPolicy,
+    validate_upload_file,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,9 +36,6 @@ class RTIRequestHistoryService:
     """
     This service is responsible for executing all RTI request history operations.
     """
-
-    ALLOWED_FILE_TYPES = [".pdf"]
-
     def __init__(self, session: Session, file_service: GithubFileService):
         self.session = session
         self.file_service = file_service
@@ -123,18 +124,20 @@ class RTIRequestHistoryService:
             # 3. Validate files
             if request_data.files:
                 for file in request_data.files:
-                    _, ext = os.path.splitext(file.filename)
-                    if not ext or ext.lower() not in self.ALLOWED_FILE_TYPES:
-                        raise BadRequestException(
-                            f"{file.filename} doesn't have a valid extension ({', '.join(self.ALLOWED_FILE_TYPES)})"
-                        )
+                    validate_upload_file(
+                        file,
+                        policy=FileValidationPolicy.RTI_HISTORY,
+                    )
 
             unique_history_id = uuid4()
             
             # 4. Upload files to GitHub
             if request_data.files:
                 for i, file in enumerate(request_data.files):
-                    _, ext = os.path.splitext(file.filename)
+                    ext = validate_upload_file(
+                        file,
+                        policy=FileValidationPolicy.RTI_HISTORY,
+                    )
                     file_path = f"rti-requests/{rti_request_id}/histories/{unique_history_id}/{unique_history_id}_{i}{ext.lower()}"
                     
                     content = await file.read()
@@ -242,18 +245,13 @@ class RTIRequestHistoryService:
 
             # 2. Handle new file uploads
             if request_data.files_to_add:
-                # Validate extensions
-                for file in request_data.files_to_add:
-                    _, ext = os.path.splitext(file.filename)
-                    if not ext or ext.lower() not in self.ALLOWED_FILE_TYPES:
-                        raise BadRequestException(
-                            f"{file.filename} doesn't have a valid extension ({', '.join(self.ALLOWED_FILE_TYPES)})"
-                        )
-                
                 # Upload new files
                 base_idx = len(history.files) if history.files else 0
                 for i, file in enumerate(request_data.files_to_add):
-                    _, ext = os.path.splitext(file.filename)
+                    ext = validate_upload_file(
+                        file,
+                        policy=FileValidationPolicy.RTI_HISTORY,
+                    )
                     file_path = f"rti-requests/{history.rti_request_id}/histories/{target_id}/{target_id}_{base_idx + i}{ext.lower()}"
                     
                     content = await file.read()
@@ -350,4 +348,3 @@ class RTIRequestHistoryService:
 
             logger.error(f"[RTI HISTORY SERVICE] Error deleting history {history_id}: {e}")
             raise InternalServerException(f"Failed to delete RTI request history: {e}") from e
-

--- a/tool/backend/src/services/rti_request_service.py
+++ b/tool/backend/src/services/rti_request_service.py
@@ -11,6 +11,10 @@ from src.models.response_models.rti_requests import RTIRequestResponse, RTIReque
 from src.models.request_models.rti_requests import RTIRequestRequest, RTIRequestUpdateRequest
 from src.core.exceptions import InternalServerException, BadRequestException, NotFoundException, ConflictException
 from datetime import datetime, timezone
+from src.utils.file_validation import (
+    FileValidationPolicy,
+    validate_upload_file,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +22,6 @@ class RTIRequestService:
     """
     This service is responsible for executing all RTI request operations.
     """
-    ALLOWED_FILE_TYPES = [".pdf"]
 
     def __init__(self, session: Session, file_service: GithubFileService):
         self.session = session
@@ -38,9 +41,10 @@ class RTIRequestService:
             if not request_data.file:
                 raise BadRequestException("RTI Request file is required")
 
-            _, ext = os.path.splitext(request_data.file.filename)
-            if not ext or ext.lower() not in self.ALLOWED_FILE_TYPES:
-                raise BadRequestException(f"{request_data.file.filename} doesn't have a valid extension ({', '.join(self.ALLOWED_FILE_TYPES)})")
+            ext = validate_upload_file(
+                request_data.file,
+                policy=FileValidationPolicy.RTI_REQUEST,
+            )
 
             # 1.1 Validate foreign keys
             if not self.session.get(Sender, request_data.sender_id):
@@ -233,9 +237,10 @@ class RTIRequestService:
 
             # 1. Update file if provided
             if request_data.file:
-                _, ext = os.path.splitext(request_data.file.filename)
-                if not ext or ext.lower() not in self.ALLOWED_FILE_TYPES:
-                    raise BadRequestException(f"{request_data.file.filename} doesn't have a valid extension ({', '.join(self.ALLOWED_FILE_TYPES)})")
+                ext = validate_upload_file(
+                    request_data.file,
+                    policy=FileValidationPolicy.RTI_REQUEST,
+                )
 
                 # Find the 'CREATED' status history to get the current file path
                 status_statement = select(RTIStatus).where(RTIStatus.name == RTIStatusName.CREATED)

--- a/tool/backend/src/services/rti_template_service.py
+++ b/tool/backend/src/services/rti_template_service.py
@@ -7,8 +7,11 @@ from src.models.request_models import RTITemplateRequest
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select, func, Session
 from src.core.exceptions import InternalServerException, BadRequestException, NotFoundException, ConflictException
+from src.utils.file_validation import (
+    FileValidationPolicy,
+    validate_upload_file,
+)
 import logging
-import os
 
 logger = logging.getLogger(__name__)
 
@@ -94,14 +97,11 @@ class RTITemplateService:
             uploaded_file_path: str | None = None  # tracks successful upload for compensating transaction
 
             # 1. upload the file
-            if template_request.file.content_type != "text/markdown":
-                raise BadRequestException(f'{template_request.file.content_type} is not allowed')
-            
+            ext = validate_upload_file(
+                template_request.file,
+                policy=FileValidationPolicy.RTI_TEMPLATE,
+            )
             content = await template_request.file.read()
-            _, ext = os.path.splitext(template_request.file.filename)
-
-            if not ext:
-                raise BadRequestException(f"{template_request.file.filename} doesn't have any file extension")
                 
             file_path = f"rti-templates/{unique_id}{ext}"
 
@@ -169,9 +169,10 @@ class RTITemplateService:
         try:
             # update the file if provided
             if template_request.file:
-                if template_request.file.content_type != "text/markdown":
-                    raise BadRequestException(f'{template_request.file.content_type} is not allowed')
-                
+                validate_upload_file(
+                    template_request.file,
+                    policy=FileValidationPolicy.RTI_TEMPLATE,
+                )
                 content = await template_request.file.read()
                 
                 # Use the existing path from the DB to ensure we update the correct file
@@ -295,5 +296,3 @@ class RTITemplateService:
                     logger.error(f"[RTI SERVICE] Compensating transaction failed — could not recreate {file_path}: {ex}")
             logger.error(f"[RTI SERVICE] Error deleting RTI template: {e}")
             raise InternalServerException(f"Failed to delete RTI template: {e}") from e
-
-

--- a/tool/backend/src/utils/__init__.py
+++ b/tool/backend/src/utils/__init__.py
@@ -1,5 +1,15 @@
 from .http_client import http_client
+from .file_validation import (
+    FILE_VALIDATION_RULES,
+    FileValidationPolicy,
+    FileValidationRules,
+    validate_upload_file,
+)
 
 __all__ = [
-    "http_client"
+    "http_client",
+    "FILE_VALIDATION_RULES",
+    "FileValidationPolicy",
+    "FileValidationRules",
+    "validate_upload_file",
 ]

--- a/tool/backend/src/utils/file_validation.py
+++ b/tool/backend/src/utils/file_validation.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from fastapi import UploadFile
+
+from src.core.exceptions import BadRequestException
+
+
+class FileValidationPolicy(StrEnum):
+    RTI_TEMPLATE = "rti_template"
+    RTI_REQUEST = "rti_request"
+    RTI_HISTORY = "rti_history"
+
+
+@dataclass(frozen=True)
+class FileValidationRules:
+    label: str
+    allowed_extensions: frozenset[str]
+    allowed_content_types: frozenset[str]
+
+
+FILE_VALIDATION_RULES = {
+    FileValidationPolicy.RTI_TEMPLATE: FileValidationRules(
+        label="RTI template file",
+        allowed_extensions=frozenset({".md"}),
+        allowed_content_types=frozenset({"text/markdown", "text/x-markdown"}),
+    ),
+    FileValidationPolicy.RTI_REQUEST: FileValidationRules(
+        label="RTI request file",
+        allowed_extensions=frozenset({".pdf"}),
+        allowed_content_types=frozenset({"application/pdf"}),
+    ),
+    FileValidationPolicy.RTI_HISTORY: FileValidationRules(
+        label="RTI history attachment",
+        allowed_extensions=frozenset({".pdf"}),
+        allowed_content_types=frozenset({"application/pdf"}),
+    ),
+}
+
+
+def _get_file_extension(filename: str | None) -> str:
+    if not filename:
+        return ""
+    return Path(filename).suffix.lower()
+
+
+def _get_file_validation_rules(policy: FileValidationPolicy) -> FileValidationRules:
+    return FILE_VALIDATION_RULES[policy]
+
+
+def _validate_file_extension(file: UploadFile, allowed_extensions: frozenset[str], label: str) -> str:
+    extension = _get_file_extension(file.filename)
+    if not extension:
+        raise BadRequestException(f"{label} must include a file extension")
+
+    if extension not in allowed_extensions:
+        allowed_list = ", ".join(sorted(allowed_extensions))
+        raise BadRequestException(
+            f"{label} has invalid extension '{extension}'. Allowed: {allowed_list}"
+        )
+
+    return extension
+
+
+def _validate_file_content_type(file: UploadFile, allowed_content_types: frozenset[str], label: str) -> None:
+    if not file.content_type or file.content_type not in allowed_content_types:
+        allowed_list = ", ".join(sorted(allowed_content_types))
+        raise BadRequestException(
+            f"{label} has invalid content type '{file.content_type}'. Allowed: {allowed_list}"
+        )
+
+
+def validate_upload_file(file: UploadFile, *, policy: FileValidationPolicy) -> str:
+    rules = _get_file_validation_rules(policy)
+    extension = _validate_file_extension(file, rules.allowed_extensions, rules.label)
+    _validate_file_content_type(file, rules.allowed_content_types, rules.label)
+    return extension

--- a/tool/backend/test/conftest.py
+++ b/tool/backend/test/conftest.py
@@ -11,6 +11,7 @@ from fastapi import UploadFile
 from sqlalchemy import event
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 from src.utils import http_client
+from src.utils.file_validation import FILE_VALIDATION_RULES, FileValidationPolicy
 from src.models import Sender, RTIStatus
 from src.models.response_models import SenderResponse
 from src.models.request_models import SenderRequest, InstitutionRequest, RTIRequestRequest, RTIRequestUpdateRequest
@@ -98,11 +99,14 @@ def rti_template_db():
 @pytest.fixture
 def make_upload_file():
     """Returns a factory for creating mock UploadFile instances."""
+    request_file_rules = FILE_VALIDATION_RULES[FileValidationPolicy.RTI_REQUEST]
+    default_content_type = next(iter(request_file_rules.allowed_content_types))
+    default_extension = next(iter(request_file_rules.allowed_extensions))
 
     def _factory(
         content: bytes = b"# Hello",
-        content_type: str = "text/markdown",
-        filename: str = "test.md",
+        content_type: str = default_content_type,
+        filename: str = f"test{default_extension}",
     ):
         mock_file = AsyncMock(spec=UploadFile)
         mock_file.content_type = content_type
@@ -661,4 +665,3 @@ def make_rti_request_update_request():
             
         return request
     return _factory
-

--- a/tool/backend/test/test_file_validation.py
+++ b/tool/backend/test/test_file_validation.py
@@ -1,0 +1,55 @@
+import pytest
+
+from src.core.exceptions import BadRequestException
+from src.utils.file_validation import FileValidationPolicy, validate_upload_file
+
+
+def test_validate_upload_file_accepts_request_pdf(make_upload_file):
+    upload = make_upload_file(content_type="application/pdf", filename="request.pdf")
+
+    extension = validate_upload_file(upload, policy=FileValidationPolicy.RTI_REQUEST)
+
+    assert extension == ".pdf"
+
+
+def test_validate_upload_file_accepts_uppercase_history_extension(make_upload_file):
+    upload = make_upload_file(content_type="application/pdf", filename="HISTORY.PDF")
+
+    extension = validate_upload_file(upload, policy=FileValidationPolicy.RTI_HISTORY)
+
+    assert extension == ".pdf"
+
+
+def test_validate_upload_file_accepts_template_markdown(make_upload_file):
+    upload = make_upload_file(content_type="text/markdown", filename="template.md")
+
+    extension = validate_upload_file(upload, policy=FileValidationPolicy.RTI_TEMPLATE)
+
+    assert extension == ".md"
+
+
+def test_validate_upload_file_rejects_missing_extension(make_upload_file):
+    upload = make_upload_file(content_type="application/pdf", filename="request")
+
+    with pytest.raises(BadRequestException) as exc:
+        validate_upload_file(upload, policy=FileValidationPolicy.RTI_REQUEST)
+
+    assert "must include a file extension" in str(exc.value)
+
+
+def test_validate_upload_file_rejects_invalid_extension(make_upload_file):
+    upload = make_upload_file(content_type="application/pdf", filename="request.txt")
+
+    with pytest.raises(BadRequestException) as exc:
+        validate_upload_file(upload, policy=FileValidationPolicy.RTI_REQUEST)
+
+    assert "invalid extension" in str(exc.value)
+
+
+def test_validate_upload_file_rejects_invalid_content_type(make_upload_file):
+    upload = make_upload_file(content_type="text/plain", filename="request.pdf")
+
+    with pytest.raises(BadRequestException) as exc:
+        validate_upload_file(upload, policy=FileValidationPolicy.RTI_REQUEST)
+
+    assert "invalid content type" in str(exc.value)

--- a/tool/backend/test/test_rti_request_history_service.py
+++ b/tool/backend/test/test_rti_request_history_service.py
@@ -213,7 +213,47 @@ async def test_create_rti_request_history_invalid_file_extension(rti_request_db,
     
     with pytest.raises(BadRequestException) as exc:
         await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
-    assert "valid extension" in str(exc.value)
+    assert "extension" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_create_rti_request_history_invalid_content_type(rti_request_db, make_file_service, make_upload_file):
+    """BadRequestException raised for unsupported history attachment MIME types."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=make_file_service())
+
+    files = [make_upload_file(filename="valid.pdf", content_type="text/plain")]
+
+    request = RTIRequestHistoryRequest(
+        statusId=status.id,
+        direction=RTIDirection.sent,
+        entryTime=datetime.now(timezone.utc),
+        files=files
+    )
+
+    with pytest.raises(BadRequestException) as exc:
+        await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+    assert "content type" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_create_rti_request_history_uppercase_extension_allowed(rti_request_db, make_file_service, make_upload_file):
+    """Uppercase history attachment extensions are normalized before validation."""
+    rti_request = create_test_rti_request(rti_request_db)
+    status = rti_request_db.exec(select(RTIStatus)).first()
+
+    fs = make_file_service(relative_path="rti-requests/hist/123.pdf")
+    service = RTIRequestHistoryService(session=rti_request_db, file_service=fs)
+
+    request = RTIRequestHistoryRequest(
+        statusId=status.id,
+        direction=RTIDirection.sent,
+        entryTime=datetime.now(timezone.utc),
+        files=[make_upload_file(filename="UPPER.PDF")]
+    )
+
+    result = await service.create_rti_request_history(rti_request_id=rti_request.id, request_data=request)
+
+    assert len(result.files) == 1
 
 @pytest.mark.asyncio
 async def test_create_rti_request_history_db_failure_rolls_back_files(rti_request_db, monkeypatch, make_file_service, make_upload_file):
@@ -632,7 +672,7 @@ async def test_update_rti_request_history_invalid_file_extension(rti_request_db,
     
     with pytest.raises(BadRequestException) as exc:
         await service.update_rti_request_history(rti_request_id=rti_request.id, request_data=request)
-    assert "valid extension" in str(exc.value)
+    assert "extension" in str(exc.value)
 
 @pytest.mark.asyncio
 async def test_update_rti_request_history_invalid_relative_path_response(rti_request_db, make_file_service, make_upload_file):
@@ -765,6 +805,4 @@ async def test_delete_rti_request_history_github_delete_failure_post_commit(rti_
     # DB record should be gone
     assert rti_request_db.get(RTIStatusHistory, history.id) is None
     fs.delete_file.assert_called_once_with(file_path=file_path)
-
-
 

--- a/tool/backend/test/test_rti_request_service.py
+++ b/tool/backend/test/test_rti_request_service.py
@@ -7,7 +7,9 @@ from sqlalchemy import text
 from sqlmodel import SQLModel, Session, create_engine, select
 from datetime import datetime, timezone
 
+import src.utils.file_validation as file_validation
 from src.services.rti_request_service import RTIRequestService
+from src.utils.file_validation import FileValidationPolicy, FileValidationRules
 from src.models.table_schemas.table_schemas import (
     RTIRequest, RTIStatus, RTIStatusHistory, RTIDirection, 
     Sender, Receiver, RTITemplate
@@ -137,7 +139,35 @@ async def test_create_rti_request_invalid_file_extension(rti_request_db, make_fi
     
     with pytest.raises(BadRequestException) as exc:
         await service.create_rti_request(request_data=request)
-    assert "valid extension" in str(exc.value)
+    assert "extension" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_create_rti_request_invalid_content_type(rti_request_db, make_file_service, make_rti_request_request):
+    """BadRequestException raised for unsupported request MIME types."""
+    sender = rti_request_db.exec(select(Sender)).first()
+    receiver = rti_request_db.exec(select(Receiver)).first()
+    service = RTIRequestService(session=rti_request_db, file_service=make_file_service())
+
+    request = make_rti_request_request(sender_id=sender.id, receiver_id=receiver.id, content_type="text/plain")
+
+    with pytest.raises(BadRequestException) as exc:
+        await service.create_rti_request(request_data=request)
+    assert "content type" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_create_rti_request_uppercase_extension_allowed(rti_request_db, make_file_service, make_rti_request_request):
+    """Uppercase request file extensions are normalized before validation."""
+    sender = rti_request_db.exec(select(Sender)).first()
+    receiver = rti_request_db.exec(select(Receiver)).first()
+
+    fs = make_file_service(relative_path="rti-requests/dir/file.pdf")
+    service = RTIRequestService(session=rti_request_db, file_service=fs)
+
+    request = make_rti_request_request(sender_id=sender.id, receiver_id=receiver.id, filename="TEST.PDF")
+
+    result = await service.create_rti_request(request_data=request)
+
+    assert result.sender.id == sender.id
 
 @pytest.mark.asyncio
 async def test_create_rti_request_missing_created_status(rti_request_db, make_file_service, make_rti_request_request):
@@ -429,7 +459,24 @@ async def test_update_rti_request_invalid_file_extension(rti_request_db, make_fi
     
     with pytest.raises(BadRequestException) as exc:
         await service.update_rti_request(request_data=update_request)
-    assert "valid extension" in str(exc.value)
+    assert "extension" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_update_rti_request_invalid_content_type(rti_request_db, make_file_service, make_rti_request_request, make_rti_request_update_request):
+    """BadRequestException raised for unsupported MIME types during update."""
+    sender = rti_request_db.exec(select(Sender)).first()
+    receiver = rti_request_db.exec(select(Receiver)).first()
+    fs = make_file_service(relative_path="rti-requests/update/file.pdf")
+    service = RTIRequestService(session=rti_request_db, file_service=fs)
+
+    create_request = make_rti_request_request(sender_id=sender.id, receiver_id=receiver.id)
+    created = await service.create_rti_request(request_data=create_request)
+
+    update_request = make_rti_request_update_request(id=created.id, filename="updated.pdf", content_type="text/plain")
+
+    with pytest.raises(BadRequestException) as exc:
+        await service.update_rti_request(request_data=update_request)
+    assert "content type" in str(exc.value)
 
 @pytest.mark.asyncio
 async def test_update_rti_request_not_found(rti_request_db, make_file_service, make_rti_request_update_request):
@@ -500,12 +547,14 @@ async def test_update_rti_request_post_commit_file_deletion_failure(rti_request_
     # Change the mock to return a .txt path for the next create_file call (during update)
     fs.create_file = AsyncMock(return_value={"relative_path": updated_path})
     
-    # To trigger delete_file, we'd need another allowed extension.
-    # We modify it temporarily and ENSURE it is restored to prevent isolation leaks.
-    original_types = list(service.ALLOWED_FILE_TYPES)
+    # To trigger delete_file, we temporarily widen the shared allowlist.
+    original_rules = file_validation.FILE_VALIDATION_RULES[FileValidationPolicy.RTI_REQUEST]
     try:
-        # this is a temporary list extending
-        service.ALLOWED_FILE_TYPES.append(".txt")
+        file_validation.FILE_VALIDATION_RULES[FileValidationPolicy.RTI_REQUEST] = FileValidationRules(
+            label=original_rules.label,
+            allowed_extensions=frozenset({".pdf", ".txt"}),
+            allowed_content_types=original_rules.allowed_content_types,
+        )
         update_request = make_rti_request_update_request(id=created.id, filename="new.txt")
         
         # This should succeed even if delete_file fails
@@ -521,7 +570,7 @@ async def test_update_rti_request_post_commit_file_deletion_failure(rti_request_
         ).first()
         assert status_history.files == [updated_path]
     finally:
-        service.ALLOWED_FILE_TYPES = original_types
+        file_validation.FILE_VALIDATION_RULES[FileValidationPolicy.RTI_REQUEST] = original_rules
 
 @pytest.mark.asyncio
 async def test_update_rti_request_missing_initial_history(rti_request_db, make_file_service, make_rti_request_request, make_rti_request_update_request):

--- a/tool/backend/test/test_rti_template_service.py
+++ b/tool/backend/test/test_rti_template_service.py
@@ -237,7 +237,32 @@ async def test_create_rti_template_no_extension(rti_template_db, make_file_servi
     with pytest.raises(BadRequestException) as exc:
         await service.create_rti_template(template_request=request)
     
-    assert "doesn't have any file extension" in str(exc.value)
+    assert "file extension" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_create_rti_template_invalid_content_type(rti_template_db, make_file_service, make_template_request):
+    """BadRequestException is raised if the uploaded template MIME type is unsupported."""
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
+
+    request = make_template_request()
+    request.file.content_type = "application/pdf"
+
+    with pytest.raises(BadRequestException) as exc:
+        await service.create_rti_template(template_request=request)
+
+    assert "content type" in str(exc.value)
+
+@pytest.mark.asyncio
+async def test_create_rti_template_uppercase_extension_allowed(rti_template_db, make_file_service, make_template_request):
+    """Uppercase template file extensions are normalized before validation."""
+    service = RTITemplateService(session=rti_template_db, file_service=make_file_service())
+
+    request = make_template_request()
+    request.file.filename = "UPPER.MD"
+
+    result = await service.create_rti_template(template_request=request)
+
+    assert result.title == request.title
 
 # update_rti_template tests
 @pytest.mark.asyncio

--- a/tool/frontend/src/constants/fileTypes.ts
+++ b/tool/frontend/src/constants/fileTypes.ts
@@ -29,11 +29,13 @@ export const fileTypeRules: Record<FileTypePolicy, FileTypeRules> = rulesByPolic
 export const getFileTypeRules = (policy: FileTypePolicy): FileTypeRules =>
   rulesByPolicy[policy];
 
-export const getPrimaryExtension = (policy: FileTypePolicy): string =>
-  rulesByPolicy[policy].extensions[0];
-
-export const getPrimaryMimeType = (policy: FileTypePolicy): string =>
-  rulesByPolicy[policy].mimeTypes[0];
+export const getDefaultGeneratedFileSpec = (policy: FileTypePolicy) => {
+  const rules = rulesByPolicy[policy];
+  return {
+    extension: rules.extensions[0],
+    mimeType: rules.mimeTypes[0],
+  };
+};
 
 export const getAcceptValue = (policy: FileTypePolicy): string => {
   const rules = rulesByPolicy[policy];
@@ -48,7 +50,7 @@ export const hasAllowedExtension = (fileName: string, policy: FileTypePolicy): b
 };
 
 export const stripPrimaryExtension = (fileName: string, policy: FileTypePolicy): string => {
-  const extension = getPrimaryExtension(policy);
+  const { extension } = getDefaultGeneratedFileSpec(policy);
   return fileName.replace(new RegExp(`${extension.replace('.', '\\.')}$`, 'i'), '');
 };
 

--- a/tool/frontend/src/constants/fileTypes.ts
+++ b/tool/frontend/src/constants/fileTypes.ts
@@ -1,9 +1,22 @@
+const rulesByPolicy = {
+  rtiRequest: {
+    label: 'RTI request file',
+    extensions: ['.pdf'],
+    mimeTypes: ['application/pdf'],
+  },
+  rtiTemplate: {
+    label: 'RTI template file',
+    extensions: ['.md'],
+    mimeTypes: ['text/markdown', 'text/x-markdown'],
+  },
+} as const;
+
 export const fileTypePolicies = {
   rtiRequest: 'rtiRequest',
   rtiTemplate: 'rtiTemplate',
 } as const;
 
-export type FileTypePolicy = (typeof fileTypePolicies)[keyof typeof fileTypePolicies];
+export type FileTypePolicy = keyof typeof rulesByPolicy;
 
 type FileTypeRules = {
   label: string;
@@ -11,36 +24,25 @@ type FileTypeRules = {
   mimeTypes: readonly string[];
 };
 
-export const fileTypeRules: Record<FileTypePolicy, FileTypeRules> = {
-  [fileTypePolicies.rtiRequest]: {
-    label: 'RTI request file',
-    extensions: ['.pdf'],
-    mimeTypes: ['application/pdf'],
-  },
-  [fileTypePolicies.rtiTemplate]: {
-    label: 'RTI template file',
-    extensions: ['.md'],
-    mimeTypes: ['text/markdown', 'text/x-markdown'],
-  },
-};
+export const fileTypeRules: Record<FileTypePolicy, FileTypeRules> = rulesByPolicy;
 
 export const getFileTypeRules = (policy: FileTypePolicy): FileTypeRules =>
-  fileTypeRules[policy];
+  rulesByPolicy[policy];
 
 export const getPrimaryExtension = (policy: FileTypePolicy): string =>
-  getFileTypeRules(policy).extensions[0];
+  rulesByPolicy[policy].extensions[0];
 
 export const getPrimaryMimeType = (policy: FileTypePolicy): string =>
-  getFileTypeRules(policy).mimeTypes[0];
+  rulesByPolicy[policy].mimeTypes[0];
 
 export const getAcceptValue = (policy: FileTypePolicy): string => {
-  const rules = getFileTypeRules(policy);
+  const rules = rulesByPolicy[policy];
   return [...rules.extensions, ...rules.mimeTypes].join(',');
 };
 
 export const hasAllowedExtension = (fileName: string, policy: FileTypePolicy): boolean => {
   const normalizedName = fileName.toLowerCase();
-  return getFileTypeRules(policy).extensions.some((extension) =>
+  return rulesByPolicy[policy].extensions.some((extension) =>
     normalizedName.endsWith(extension.toLowerCase())
   );
 };
@@ -51,6 +53,6 @@ export const stripPrimaryExtension = (fileName: string, policy: FileTypePolicy):
 };
 
 export const isAcceptedFile = (file: File, policy: FileTypePolicy): boolean => {
-  const rules = getFileTypeRules(policy);
+  const rules = rulesByPolicy[policy];
   return rules.mimeTypes.includes(file.type) && hasAllowedExtension(file.name, policy);
 };

--- a/tool/frontend/src/constants/fileTypes.ts
+++ b/tool/frontend/src/constants/fileTypes.ts
@@ -1,0 +1,56 @@
+export const fileTypePolicies = {
+  rtiRequest: 'rtiRequest',
+  rtiTemplate: 'rtiTemplate',
+} as const;
+
+export type FileTypePolicy = (typeof fileTypePolicies)[keyof typeof fileTypePolicies];
+
+type FileTypeRules = {
+  label: string;
+  extensions: readonly string[];
+  mimeTypes: readonly string[];
+};
+
+export const fileTypeRules: Record<FileTypePolicy, FileTypeRules> = {
+  [fileTypePolicies.rtiRequest]: {
+    label: 'RTI request file',
+    extensions: ['.pdf'],
+    mimeTypes: ['application/pdf'],
+  },
+  [fileTypePolicies.rtiTemplate]: {
+    label: 'RTI template file',
+    extensions: ['.md'],
+    mimeTypes: ['text/markdown', 'text/x-markdown'],
+  },
+};
+
+export const getFileTypeRules = (policy: FileTypePolicy): FileTypeRules =>
+  fileTypeRules[policy];
+
+export const getPrimaryExtension = (policy: FileTypePolicy): string =>
+  getFileTypeRules(policy).extensions[0];
+
+export const getPrimaryMimeType = (policy: FileTypePolicy): string =>
+  getFileTypeRules(policy).mimeTypes[0];
+
+export const getAcceptValue = (policy: FileTypePolicy): string => {
+  const rules = getFileTypeRules(policy);
+  return [...rules.extensions, ...rules.mimeTypes].join(',');
+};
+
+export const hasAllowedExtension = (fileName: string, policy: FileTypePolicy): boolean => {
+  const normalizedName = fileName.toLowerCase();
+  return getFileTypeRules(policy).extensions.some((extension) =>
+    normalizedName.endsWith(extension.toLowerCase())
+  );
+};
+
+export const stripPrimaryExtension = (fileName: string, policy: FileTypePolicy): string => {
+  const extension = getPrimaryExtension(policy);
+  return fileName.replace(new RegExp(`${extension.replace('.', '\\.')}$`, 'i'), '');
+};
+
+export const isAcceptedFile = (file: File, policy: FileTypePolicy): boolean => {
+  const rules = getFileTypeRules(policy);
+  return rules.mimeTypes.includes(file.type) || hasAllowedExtension(file.name, policy);
+};

--- a/tool/frontend/src/constants/fileTypes.ts
+++ b/tool/frontend/src/constants/fileTypes.ts
@@ -4,6 +4,11 @@ const rulesByPolicy = {
     extensions: ['.pdf'],
     mimeTypes: ['application/pdf'],
   },
+  rtiHistory: {
+    label: 'RTI history attachment',
+    extensions: ['.pdf'],
+    mimeTypes: ['application/pdf'],
+  },
   rtiTemplate: {
     label: 'RTI template file',
     extensions: ['.md'],
@@ -13,6 +18,7 @@ const rulesByPolicy = {
 
 export const fileTypePolicies = {
   rtiRequest: 'rtiRequest',
+  rtiHistory: 'rtiHistory',
   rtiTemplate: 'rtiTemplate',
 } as const;
 

--- a/tool/frontend/src/constants/fileTypes.ts
+++ b/tool/frontend/src/constants/fileTypes.ts
@@ -52,5 +52,5 @@ export const stripPrimaryExtension = (fileName: string, policy: FileTypePolicy):
 
 export const isAcceptedFile = (file: File, policy: FileTypePolicy): boolean => {
   const rules = getFileTypeRules(policy);
-  return rules.mimeTypes.includes(file.type) || hasAllowedExtension(file.name, policy);
+  return rules.mimeTypes.includes(file.type) && hasAllowedExtension(file.name, policy);
 };

--- a/tool/frontend/src/pages/RTIDetail.tsx
+++ b/tool/frontend/src/pages/RTIDetail.tsx
@@ -9,10 +9,12 @@ import { Button } from '../components/Button';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import toast from 'react-hot-toast';
 import { config } from '../config';
+import { fileTypePolicies, getAcceptValue, getPrimaryExtension } from '../constants/fileTypes';
 
 const FILE_VIEW_BASE_URL = config.FILE_VIEW_BASE_URL;
 
 export function RTIDetail() {
+  const requestFilePolicy = fileTypePolicies.rtiRequest;
   const { id } = useParams();
   const navigate = useNavigate();
 
@@ -485,7 +487,7 @@ export function RTIDetail() {
                     id="file-upload"
                     type="file"
                     multiple
-                    accept=".pdf"
+                    accept={getAcceptValue(requestFilePolicy)}
                     onChange={(e) => {
                       const files = Array.from(e.target.files || []);
                       setEventFormData({ ...eventFormData, newFiles: [...eventFormData.newFiles, ...files] });
@@ -508,7 +510,7 @@ export function RTIDetail() {
                     {eventFormData.existingFiles.map((_, i) => (
                       <div key={`exist-${i}`} className="flex items-center gap-1.5 text-[10px] bg-blue-50 border border-blue-100 px-2 py-1 rounded-lg text-blue-700 font-bold group">
                         <FileText className="w-2.5 h-2.5" />
-                        <span className="truncate max-w-[120px]">{`File ${i + 1}.pdf`}</span>
+                        <span className="truncate max-w-[120px]">{`File ${i + 1}${getPrimaryExtension(requestFilePolicy)}`}</span>
                         <button
                           type="button"
                           onClick={() => setEventFormData({

--- a/tool/frontend/src/pages/RTIDetail.tsx
+++ b/tool/frontend/src/pages/RTIDetail.tsx
@@ -9,7 +9,7 @@ import { Button } from '../components/Button';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import toast from 'react-hot-toast';
 import { config } from '../config';
-import { fileTypePolicies, getAcceptValue, getPrimaryExtension } from '../constants/fileTypes';
+import { fileTypePolicies, getAcceptValue, getDefaultGeneratedFileSpec } from '../constants/fileTypes';
 
 const FILE_VIEW_BASE_URL = config.FILE_VIEW_BASE_URL;
 
@@ -30,6 +30,7 @@ export function RTIDetail() {
   const deleteHistoryMutation = useDeleteRtiRequestHistory();
 
   const history = (historyResponse?.data || [])
+  const { extension: generatedFileExtension } = getDefaultGeneratedFileSpec(requestFilePolicy);
 
   // Event Modal State
   const [isEventModalOpen, setIsEventModalOpen] = useState(false);
@@ -510,7 +511,7 @@ export function RTIDetail() {
                     {eventFormData.existingFiles.map((_, i) => (
                       <div key={`exist-${i}`} className="flex items-center gap-1.5 text-[10px] bg-blue-50 border border-blue-100 px-2 py-1 rounded-lg text-blue-700 font-bold group">
                         <FileText className="w-2.5 h-2.5" />
-                        <span className="truncate max-w-[120px]">{`File ${i + 1}${getPrimaryExtension(requestFilePolicy)}`}</span>
+                        <span className="truncate max-w-[120px]">{`File ${i + 1}${generatedFileExtension}`}</span>
                         <button
                           type="button"
                           onClick={() => setEventFormData({

--- a/tool/frontend/src/pages/RTIRequests.tsx
+++ b/tool/frontend/src/pages/RTIRequests.tsx
@@ -17,6 +17,13 @@ import { Column } from '../types/table';
 import { sendersService } from '../services/sendersService';
 import { getVariableValues } from '../utils/variableUtils';
 import getStatusColor from '../utils/styleUtils';
+import {
+  fileTypePolicies,
+  getAcceptValue,
+  getPrimaryMimeType,
+  isAcceptedFile,
+  stripPrimaryExtension,
+} from '../constants/fileTypes';
 
 import { useRTIRequest } from '../hooks/useRTIRequest';
 import { useEntityData } from '../hooks/useEntityData';
@@ -26,6 +33,7 @@ import { useDebounce } from '../hooks/useDebounce';
 type View = 'list' | 'create';
 
 export function RTIRequests() {
+  const requestFilePolicy = fileTypePolicies.rtiRequest;
   const navigate = useNavigate();
   const [view, setView] = useState<View>('list');
   const [search, setSearch] = useState('');
@@ -90,12 +98,12 @@ export function RTIRequests() {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      if (file.type !== 'application/pdf') {
+      if (!isAcceptedFile(file, requestFilePolicy)) {
         toast.error('Please upload a PDF file');
         return;
       }
       setUploadedFile(file);
-      setFormData(prev => ({ ...prev, title: file.name.replace(/\.pdf$/i, '') }));
+      setFormData(prev => ({ ...prev, title: stripPrimaryExtension(file.name, requestFilePolicy) }));
       setSelectionMode('upload');
       setStep(2);
     }
@@ -151,7 +159,7 @@ export function RTIRequests() {
           receiver,
           content: rawContent
         });
-        pdfFile = new File([blob], fileName, { type: 'application/pdf' });
+        pdfFile = new File([blob], fileName, { type: getPrimaryMimeType(requestFilePolicy) });
         finalMarkdown = generatedMarkdown;
         downloadBlob(blob, fileName);
       }
@@ -270,7 +278,7 @@ export function RTIRequests() {
                     <h3 className="text-xl font-bold text-gray-900 mb-2">Upload File</h3>
                     <p className="text-sm text-gray-600 mb-6">Upload a PDF from device</p>
                     <Button variant="outline" size="sm" className="px-6 border-green-600 text-green-700 hover:bg-green-600 hover:text-white">Select PDF</Button>
-                    <input type="file" ref={fileInputRef} className="hidden" accept=".pdf" onChange={handleFileChange} />
+                    <input type="file" ref={fileInputRef} className="hidden" accept={getAcceptValue(requestFilePolicy)} onChange={handleFileChange} />
                   </div>
                 </div>
               ) : (

--- a/tool/frontend/src/pages/RTIRequests.tsx
+++ b/tool/frontend/src/pages/RTIRequests.tsx
@@ -18,9 +18,9 @@ import { sendersService } from '../services/sendersService';
 import { getVariableValues } from '../utils/variableUtils';
 import getStatusColor from '../utils/styleUtils';
 import {
+  getDefaultGeneratedFileSpec,
   fileTypePolicies,
   getAcceptValue,
-  getPrimaryMimeType,
   isAcceptedFile,
   stripPrimaryExtension,
 } from '../constants/fileTypes';
@@ -152,6 +152,7 @@ export function RTIRequests() {
         pdfFile = uploadedFile;
         finalMarkdown = 'File uploaded manually';
       } else {
+        const { mimeType } = getDefaultGeneratedFileSpec(requestFilePolicy);
         const { blob, fileName, finalMarkdown: generatedMarkdown } = await generateRTIPDF({
           title: formData.title,
           requestDate: formData.requestDate,
@@ -159,7 +160,7 @@ export function RTIRequests() {
           receiver,
           content: rawContent
         });
-        pdfFile = new File([blob], fileName, { type: getPrimaryMimeType(requestFilePolicy) });
+        pdfFile = new File([blob], fileName, { type: mimeType });
         finalMarkdown = generatedMarkdown;
         downloadBlob(blob, fileName);
       }

--- a/tool/frontend/src/services/templateService.ts
+++ b/tool/frontend/src/services/templateService.ts
@@ -2,7 +2,7 @@ import { Template } from '../types/rti';
 import { AsgardeoContextProps } from '@asgardeo/react';
 import { ListResponse } from '../types/api';
 import { config } from '../config';
-import { fileTypePolicies, getPrimaryExtension, getPrimaryMimeType } from '../constants/fileTypes';
+import { fileTypePolicies, getDefaultGeneratedFileSpec } from '../constants/fileTypes';
 
 const API_BASE_URL = config.RTI_TRACKER_SERVER_URL;
 const FILE_STORAGE_BASE_URL = config.FILE_STORAGE_BASE_URL;
@@ -18,8 +18,9 @@ const toFormData = (title?: string, description?: string, content?: string): For
 
   if (content !== undefined) {
     // Convert content string to physical Markdown file for GitHub storage
-    const fileBlob = new Blob([content], { type: getPrimaryMimeType(templateFilePolicy) });
-    const fileName = `${(title || 'template').replace(/\s+/g, '_')}${getPrimaryExtension(templateFilePolicy)}`;
+    const generatedFileSpec = getDefaultGeneratedFileSpec(templateFilePolicy);
+    const fileBlob = new Blob([content], { type: generatedFileSpec.mimeType });
+    const fileName = `${(title || 'template').replace(/\s+/g, '_')}${generatedFileSpec.extension}`;
     formData.append('file', fileBlob, fileName);
   }
   return formData;

--- a/tool/frontend/src/services/templateService.ts
+++ b/tool/frontend/src/services/templateService.ts
@@ -2,9 +2,11 @@ import { Template } from '../types/rti';
 import { AsgardeoContextProps } from '@asgardeo/react';
 import { ListResponse } from '../types/api';
 import { config } from '../config';
+import { fileTypePolicies, getPrimaryExtension, getPrimaryMimeType } from '../constants/fileTypes';
 
 const API_BASE_URL = config.RTI_TRACKER_SERVER_URL;
 const FILE_STORAGE_BASE_URL = config.FILE_STORAGE_BASE_URL;
+const templateFilePolicy = fileTypePolicies.rtiTemplate;
 
 /**
  * Helper to convert template fields and content into Multipart FormData.
@@ -16,8 +18,8 @@ const toFormData = (title?: string, description?: string, content?: string): For
 
   if (content !== undefined) {
     // Convert content string to physical Markdown file for GitHub storage
-    const fileBlob = new Blob([content], { type: 'text/markdown' });
-    const fileName = `${(title || 'template').replace(/\s+/g, '_')}.md`;
+    const fileBlob = new Blob([content], { type: getPrimaryMimeType(templateFilePolicy) });
+    const fileName = `${(title || 'template').replace(/\s+/g, '_')}${getPrimaryExtension(templateFilePolicy)}`;
     formData.append('file', fileBlob, fileName);
   }
   return formData;


### PR DESCRIPTION
centralizes file validation rules across backend + frontend.

- move validation to shared policy-based helpers
- enforce mime + extension checks consistently
- add coverage for invalid mime / extension cases

closes #106